### PR TITLE
Add 1rem padding to the root of the <blui-empty-state> component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
 # Change Log
+
+## v6.0.2 (Unreleased)
+
+### Changed
+
+-   Added 1rem default padding to `<blui-empty-state>` ([#336](https://github.com/brightlayer-ui/angular-component-library/issues/336)).
+
 ## v6.0.1 (December 17, 2021)
 
 ### Fixed
 
--   Fixed `<pxb-score-card>` cutting off descender letters.
+-   Fixed `<blui-score-card>` cutting off descender letters.
+
 ## v6.0.0 (November 3, 2021)
 
 ### Changed
@@ -27,14 +35,13 @@ Previous versions listed after this indicator refer to our deprecated `@pxblue` 
 -   Changed `<pxb-user-menu>` `open` property to be required instead of optional.
 -   Changed `<pxb-user-menu>` component to use a new `UserMenuHeaderComponent` in the menu overlay instead of using a `DrawerHeaderComponent`.
 
-
 ### Fixed
 
 -   Fixed stepper spacing in `<pxb-mobile-stepper>` when Back and Next buttons are uneven width.
 -   Fixed bug in `<pxb-user-menu>` that prevented the bottom sheet from rendering when `open` was manually set to `true`.
 -   Fixed bug in `<pxb-user-menu>` where dismissing a bottomsheet via backdrop click did not emit a `backdropClick` event.
 -   Fixed bug in `<pxb-app-bar>` that prevented class overrides on the root element.
--   Fixed bug in `<pxb-app-bar>` so scroll listeners can no longer attempt to measure `undefined` elements' scroll distance. 
+-   Fixed bug in `<pxb-app-bar>` so scroll listeners can no longer attempt to measure `undefined` elements' scroll distance.
 
 ## v5.0.1 (July 30, 2021)
 

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@brightlayer-ui/angular-components",
-    "version": "6.0.1",
+    "version": "6.0.2-beta.0",
     "description": "Angular components for Brightlayer UI applications",
     "scripts": {
         "ng": "ng",

--- a/components/src/core/empty-state/empty-state.component.scss
+++ b/components/src/core/empty-state/empty-state.component.scss
@@ -5,6 +5,7 @@
 .blui-empty-state-content {
     height: 100%;
     width: 100%;
+    padding: 1rem;
     display: flex;
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #336 && PXBLUE-2720.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add 1rem padding to the root of the `<blui-empty-state>` component

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![Screen Shot 2022-01-04 at 10 04 29 AM](https://user-images.githubusercontent.com/13989985/148081040-55b9c8a4-5255-499b-b496-c6b389f76d77.png)

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Run showcase
- Navigate to an empty state story
- Resize the window or inspect the element to see that there is now a 1rem padding on the root of the `<blui-empty-state>` component

To be sure that this style can be overridden you can add
`styles: ['::ng-deep .blui-empty-state-content {padding:0 !important}']` to one of the empty-state stories to test.
