### PR TITLE
Bug/2723 dynamic appbar el

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
--   Fixed `<blui-app-bar>` not listening for new scroll elements `onChanges`.
+-   Fixed `<blui-app-bar>` not listening for new scroll elements `onChanges` ([#362](https://github.com/brightlayer-ui/angular-component-library/issues/362)).
 
 ## v6.0.1 (December 17, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@
 
 -   Added 1rem default padding to `<blui-empty-state>` ([#336](https://github.com/brightlayer-ui/angular-component-library/issues/336)).
 
+### Fixed
+
+-   Fixed `<blui-app-bar>` not listening for new scroll elements `onChanges`.
+
 ## v6.0.1 (December 17, 2021)
 
 ### Fixed
 
 -   Fixed `<blui-score-card>` cutting off descender letters.
--   Fixed `<blui-app-bar`> not listening for new scroll elements `onChanges`. 
 
 ## v6.0.0 (November 3, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 -   Fixed `<blui-score-card>` cutting off descender letters.
+-   Fixed `<blui-app-bar`> not listening for new scroll elements `onChanges`. 
 
 ## v6.0.0 (November 3, 2021)
 

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@brightlayer-ui/angular-components",
-    "version": "6.0.2-beta.0",
+    "version": "6.0.2-beta.1",
     "description": "Angular components for Brightlayer UI applications",
     "scripts": {
         "ng": "ng",

--- a/components/src/core/app-bar/app-bar.component.ts
+++ b/components/src/core/app-bar/app-bar.component.ts
@@ -118,7 +118,7 @@ export class AppBarComponent implements OnInit, AfterViewInit, OnChanges, OnDest
         this.expandedHeight = Number(this.expandedHeight);
         this.collapsedHeight = Number(this.collapsedHeight);
 
-        if (changes.scrollContainerClassName || changes.scrollContainerId) {
+        if (changes.scrollContainerClassName || changes.scrollContainerId || changes.scrollContainerElement) {
             this._listenForScrollEvents();
         }
 

--- a/components/src/core/app-bar/app-bar.component.ts
+++ b/components/src/core/app-bar/app-bar.component.ts
@@ -119,7 +119,6 @@ export class AppBarComponent implements OnInit, AfterViewInit, OnChanges, OnDest
         this.collapsedHeight = Number(this.collapsedHeight);
 
         if (changes.scrollContainerClassName || changes.scrollContainerId) {
-            console.log(changes);
             this._listenForScrollEvents();
         }
 

--- a/components/src/core/app-bar/app-bar.component.ts
+++ b/components/src/core/app-bar/app-bar.component.ts
@@ -117,30 +117,24 @@ export class AppBarComponent implements OnInit, AfterViewInit, OnChanges, OnDest
         this.useDefaultCollapsedHeight = isNaN(this.collapsedHeight) || this.collapsedHeight === 0;
         this.expandedHeight = Number(this.expandedHeight);
         this.collapsedHeight = Number(this.collapsedHeight);
+
+        if (changes.scrollContainerClassName || changes.scrollContainerId) {
+            console.log(changes);
+            this._listenForScrollEvents();
+        }
+
         this._ref.detectChanges();
     }
 
     ngAfterViewInit(): void {
-        this._setScrollEl();
-        this._resizeOnModeChange();
-        this.viewInit = true;
-
-        if (this.scrollEl) {
-            this.scrollListener = fromEvent(this.scrollEl, 'scroll')
-                .pipe(throttle(() => interval(10)))
-                .subscribe(() => {
-                    this._resizeEl();
-                });
-
-            this.resizeListener = fromEvent(window, 'resize')
-                .pipe(throttle(() => interval(10)))
-                .subscribe(() => {
-                    this._resizeEl();
-                });
-        }
+        this._listenForScrollEvents();
     }
 
     ngOnDestroy(): void {
+        this._stopListeningForScrollEvents();
+    }
+
+    private _stopListeningForScrollEvents(): void {
         if (this.scrollListener) {
             this.scrollListener.unsubscribe();
         }
@@ -156,6 +150,26 @@ export class AppBarComponent implements OnInit, AfterViewInit, OnChanges, OnDest
             return `${this.collapsedHeight}px`;
         }
         return `${this._calcDefaultCollapsedHeight()}rem`;
+    }
+
+    private _listenForScrollEvents(): void {
+        this._setScrollEl();
+        this._resizeOnModeChange();
+        this._stopListeningForScrollEvents();
+        this.viewInit = true;
+        if (this.scrollEl) {
+            this.scrollListener = fromEvent(this.scrollEl, 'scroll')
+                .pipe(throttle(() => interval(10)))
+                .subscribe(() => {
+                    this._resizeEl();
+                });
+
+            this.resizeListener = fromEvent(window, 'resize')
+                .pipe(throttle(() => interval(10)))
+                .subscribe(() => {
+                    this._resizeEl();
+                });
+        }
     }
 
     private _resizeOnModeChange(): void {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #362 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Whenever a `scrollContainerClassName`, `scrollContainerId`, or `scrollContainerElement` input changes, stop listening to scroll events and re-initialize the scroll listeners. 

#### To Test
I have a local branch of the showcase that I've used to test and will share.  
