### PR TITLE
Adjust script to nuke .git file if package.json doesnt exist

### DIFF
--- a/scripts/initializeSubmodule.sh
+++ b/scripts/initializeSubmodule.sh
@@ -9,9 +9,13 @@ BGREEN='\033[1;32m' #BOLD
 GRAY='\033[1;30m'
 NC='\033[0m' # No Color
 
+if [ ! -f ./demos/showcase/package.json ];
+    then echo -e "${BBLUE}Emptying Showcase Folder${NC}" && rm -r ./demos/showcase/*
+fi
+
 echo -e "${BLUE}Initializing Showcase Submodule...${NC}"
 if [ ! -f ./demos/showcase/package.json ];
-    then rm ./demos/showcase/.git & git submodule init && git submodule update;
+    then git submodule init && git submodule update;
     else echo -e "${BBLUE}Already initialized${NC}" && exit 0;
 fi
 echo -e "${BBLUE}Initialization Complete${NC}\r\n"

--- a/scripts/initializeSubmodule.sh
+++ b/scripts/initializeSubmodule.sh
@@ -11,7 +11,7 @@ NC='\033[0m' # No Color
 
 echo -e "${BLUE}Initializing Showcase Submodule...${NC}"
 if [ ! -f ./demos/showcase/package.json ];
-    then git submodule init && git submodule update;
+    then rm ./demos/showcase/.git & git submodule init && git submodule update;
     else echo -e "${BBLUE}Already initialized${NC}" && exit 0;
 fi
 echo -e "${BBLUE}Initialization Complete${NC}\r\n"


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #317 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add a `rm .git` step to the initialization script if `package.json` not found.
- This step completely resets the demos/showcase folder & allows initialization to happen as if the folder was empty.

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Clone repo, `yarn start:storybook` then run `yarn start:showcase`.  
