### PR TITLE
fix menu icon in temporary drawer

### DIFF
--- a/demos/storybook/stories/drawer/within-drawer-layout-rail.stories.ts
+++ b/demos/storybook/stories/drawer/within-drawer-layout-rail.stories.ts
@@ -44,7 +44,7 @@ export const withinDrawerLayoutRail = (): any => ({
                </blui-drawer-footer>
             </blui-drawer>
             <div blui-content>
-                <mat-toolbar [style.backgroundColor]="blue" [style.color]="white" class="app-bar">
+                <mat-toolbar color="primary" class="app-bar">
                     <button *ngIf="variant === 'temporary'" mat-icon-button 
                         [style.marginRight.px]="direction() === 'rtl' ? -16 : 16"
                         [style.marginLeft.px]="direction() === 'rtl' ? 16 : -16"

--- a/demos/storybook/stories/drawer/within-drawer-layout.stories.ts
+++ b/demos/storybook/stories/drawer/within-drawer-layout.stories.ts
@@ -53,7 +53,7 @@ export const withinDrawerLayout = (): any => ({
                </blui-drawer-body>
             </blui-drawer>
             <div blui-content>
-                <mat-toolbar [style.backgroundColor]="blue" [style.color]="white" class="app-bar">
+                <mat-toolbar color="primary" class="app-bar">
                     <button *ngIf="variant === 'temporary'" mat-icon-button 
                         class="scale-button"
                         [style.marginRight.px]="direction() === 'rtl' ? -16 : 16"


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes [325](https://github.com/brightlayer-ui/angular-component-library/issues/325) .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Fix menu icon in temporary drawer

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
<img width="1000" alt="Screenshot 2022-01-13 at 1 54 34 PM" src="https://user-images.githubusercontent.com/10433274/149294149-3d1cf95e-20c9-4fec-b2ae-192b50932c33.png">
<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:

- http://localhost:6006/?path=/story/components-drawer--within-a-drawer-layout
- Switch knob to temporary
- Click on the dark drop to dismiss the drawer
- Menu Icon should be white50.
