### PR TITLE
Feature/fix nav item depth v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 -   Fixed `<blui-app-bar>` not listening for new scroll elements `onChanges` ([#362](https://github.com/brightlayer-ui/angular-component-library/issues/362)).
 -   Fixed `<blui-user-menu>` not rendering bottomsheet content when quickly dismissing and then reopening. ([#345](https://github.com/brightlayer-ui/angular-component-library/issues/345))
 -   Fixed `<blui-drawer-nav-item>` not responding to `expanded` input updates. ([#326](https://github.com/brightlayer-ui/angular-component-library/issues/326))
+-   Fixed `<blui-drawer-nav-item>` not applying correct `depth` class for asynchronously loaded items. ([#356](https://github.com/brightlayer-ui/angular-component-library/issues/356))
 
 
 ## v6.0.1 (December 17, 2021)

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@brightlayer-ui/angular-components",
-    "version": "6.0.2-beta.2",
+    "version": "6.0.2-beta.3",
     "description": "Angular components for Brightlayer UI applications",
     "scripts": {
         "ng": "ng",

--- a/components/src/core/drawer/drawer-body/nav-group/drawer-nav-group.component.ts
+++ b/components/src/core/drawer/drawer-body/nav-group/drawer-nav-group.component.ts
@@ -1,5 +1,5 @@
 import {
-    AfterContentChecked,
+    AfterViewInit,
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
@@ -68,10 +68,7 @@ export type DrawerNavGroup = {
         class: 'blui-drawer-nav-group',
     },
 })
-export class DrawerNavGroupComponent
-    extends StateListener
-    implements Omit<DrawerNavGroup, 'items'>, AfterContentChecked
-{
+export class DrawerNavGroupComponent extends StateListener implements Omit<DrawerNavGroup, 'items'>, AfterViewInit {
     /** Whether to show a dividing line below the title */
     @Input() divider = false;
     /** Component to render a group title */
@@ -82,14 +79,23 @@ export class DrawerNavGroupComponent
         super(drawerService, changeDetectorRef);
     }
 
-    /** Iterates through top-level NavItem children and sets defaults.
-     *  This is ran AfterContentChecked instead of AfterContentInit to account for asynchronously added navigation items.
-     * */
-    ngAfterContentChecked(): void {
-        for (const navItem of this.navItems) {
-            if (navItem.depth === undefined) {
-                navItem.setNavItemDefaults();
-            }
+    /** Whenever a new navigation item is created async or conditionally,
+     * re-iterate through the navigation tree to assign the correct depth and top-level or nested state defaults to it. */
+    ngAfterViewInit(): void {
+        this._initializeNavItemDefaults(0, this.navItems);
+
+        // This is only called for async or conditionally loaded items.
+        this.drawerService.drawerNewNavItemCreated().subscribe(() => {
+            setTimeout(() => {
+                this._initializeNavItemDefaults(0, this.navItems);
+            });
+        });
+    }
+
+    private _initializeNavItemDefaults(depth: number, navItems: DrawerNavItemComponent[]): void {
+        for (const item of navItems) {
+            item.incrementDepth(depth);
+            this._initializeNavItemDefaults(depth + 1, item.nestedNavItems);
         }
     }
 }

--- a/components/src/core/drawer/drawer-body/nav-group/drawer-nav-group.component.ts
+++ b/components/src/core/drawer/drawer-body/nav-group/drawer-nav-group.component.ts
@@ -1,4 +1,5 @@
 import {
+    AfterContentChecked,
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
@@ -67,7 +68,10 @@ export type DrawerNavGroup = {
         class: 'blui-drawer-nav-group',
     },
 })
-export class DrawerNavGroupComponent extends StateListener implements Omit<DrawerNavGroup, 'items'> {
+export class DrawerNavGroupComponent
+    extends StateListener
+    implements Omit<DrawerNavGroup, 'items'>, AfterContentChecked
+{
     /** Whether to show a dividing line below the title */
     @Input() divider = false;
     /** Component to render a group title */
@@ -78,9 +82,14 @@ export class DrawerNavGroupComponent extends StateListener implements Omit<Drawe
         super(drawerService, changeDetectorRef);
     }
 
-    ngAfterContentInit(): void {
+    /** Iterates through top-level NavItem children and sets defaults.
+     *  This is ran AfterContentChecked instead of AfterContentInit to account for asynchronously added navigation items.
+     * */
+    ngAfterContentChecked(): void {
         for (const navItem of this.navItems) {
-            navItem.setNavItemDefaults();
+            if (navItem.depth === undefined) {
+                navItem.setNavItemDefaults();
+            }
         }
     }
 }

--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.spec.ts
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.spec.ts
@@ -44,6 +44,7 @@ describe('DrawerNavItemComponent', () => {
     it('should enforce class naming conventions', () => {
         component.hasChildren = true;
         component.selected = true;
+        component.depth = 1;
         spyOn(component, 'isOpen').and.returnValue(true);
         spyOn(component, 'ngAfterContentInit').and.stub();
         spyOn(component, 'isEmpty').and.returnValue(true);
@@ -55,6 +56,7 @@ describe('DrawerNavItemComponent', () => {
             '.blui-drawer-nav-item-active-square',
             '.blui-drawer-nav-item-active',
             '.blui-drawer-nav-item-active-highlight',
+            '.blui-drawer-nav-item-depth-1',
         ];
         for (const className of classList) {
             count(fixture, className);

--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
@@ -257,6 +257,7 @@ export class DrawerNavItemComponent extends StateListener implements Omit<Drawer
         });
     }
 
+    /** A top-level navigation item has a depth of 1. */
     incrementDepth(parentDepth: number): void {
         if (parentDepth > 0) {
             this.setNestedDrawerDefaults();

--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
@@ -304,7 +304,7 @@ export class DrawerNavItemComponent extends StateListener implements Omit<Drawer
     }
 
     /** Sets default state values for nested nav items. */
-    public setNestedDrawerDefaults(): void {
+    setNestedDrawerDefaults(): void {
         if (this.divider === undefined) this.divider = false;
         if (this.hidePadding === undefined) this.hidePadding = false;
     }

--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
@@ -230,6 +230,10 @@ export class DrawerNavItemComponent
     }
 
     handleExpand(): void {
+        if (!this.matExpansionPanel) {
+            return;
+        }
+
         setTimeout(() => {
             // Persistent drawers will only expand if they the drawer is opened.
             // Temporary drawers will always have any expansion panels opened.

--- a/components/src/core/drawer/service/drawer.service.ts
+++ b/components/src/core/drawer/service/drawer.service.ts
@@ -20,6 +20,7 @@ export class DrawerService {
     drawerOpenObs = new Subject<boolean>();
     drawerSelectObs = new Subject<boolean>();
     drawerActiveItemChangeObs = new Subject<boolean>();
+    drawerNewNavItemInit = new Subject<void>();
 
     hasSideBorder(): boolean {
         return this.sideBorder;
@@ -111,6 +112,14 @@ export class DrawerService {
 
     drawerActiveItemChanges(): Observable<boolean> {
         return this.drawerActiveItemChangeObs;
+    }
+
+    drawerNewNavItemCreated(): Observable<void> {
+        return this.drawerNewNavItemInit;
+    }
+
+    emitNewNavItemCreated(): void {
+        this.drawerNewNavItemInit.next();
     }
 
     /** Each nav item has a unique id which is used to determine which item is selected. */


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #356 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Change the way `DrawerNavItemComponents` are initialized so that the `depth` class is applied for async-loaded nav items. 

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- In the submitted issue, there was a demo project provided that had 2 `NavGroups`.  One group had items added synchronously and the other async.  The async-loaded group didn't have a "depth-class" applied to each item.
- https://github.com/emclaug2/async-nav-item-depth has a demo that has been updated to use a local copy of the component library.  Now both `NavGroups` should have the "depth-class" applied.   There are also a few navigation items that are rendered over time; these items should also have the "depth-class" applied. 


