### PR TITLE
Bug/391 drawer expand on init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v6.0.3 (not yet published)
+
+### Fixed
+
+-   Fixed `<blui-drawer-nav-item>` not responding to `expanded` input on initialization. ([#391](https://github.com/brightlayer-ui/angular-component-library/issues/391))
+
 ## v6.0.2 (January 20, 2022)
 
 ### Changed

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@brightlayer-ui/angular-components",
-    "version": "6.0.2",
+    "version": "6.0.3-beta.0",
     "description": "Angular components for Brightlayer UI applications",
     "scripts": {
         "ng": "ng",

--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
@@ -128,10 +128,7 @@ export type ActiveItemBackgroundShape = 'round' | 'square';
         class: 'blui-drawer-nav-item',
     },
 })
-export class DrawerNavItemComponent
-    extends StateListener
-    implements Omit<DrawerNavItem, 'items'>, AfterContentInit
-{
+export class DrawerNavItemComponent extends StateListener implements Omit<DrawerNavItem, 'items'>, AfterContentInit {
     /** Sets the active item background shape
      *
      * `square` - Background shape takes the entire height of width of the NavItem.
@@ -226,16 +223,16 @@ export class DrawerNavItemComponent
 
     handleExpand(): void {
         setTimeout(() => {
-          if (!this.matExpansionPanel) {
-            return;
-          }
-          // Persistent drawers will only expand if they the drawer is opened.
-          // Temporary drawers will always have any expansion panels opened.
-          if (this.expanded && (this.isOpen() || this.drawerService.getDrawerVariant() === 'temporary')) {
-            this.matExpansionPanel.open();
-          } else {
-            this.matExpansionPanel.close();
-          }
+            if (!this.matExpansionPanel) {
+                return;
+            }
+            // Persistent drawers will only expand if they the drawer is opened.
+            // Temporary drawers will always have any expansion panels opened.
+            if (this.expanded && (this.isOpen() || this.drawerService.getDrawerVariant() === 'temporary')) {
+                this.matExpansionPanel.open();
+            } else {
+                this.matExpansionPanel.close();
+            }
         });
     }
 
@@ -295,7 +292,7 @@ export class DrawerNavItemComponent
         this.depth = parentDepth + 1;
         this.hasChildren = this.nestedNavItems && this.nestedNavItems.length > 0;
         if (this.hasChildren && this.expanded === true) {
-          this.handleExpand();
+            this.handleExpand();
         }
         this.changeDetector.detectChanges();
     }

--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
@@ -1,6 +1,5 @@
 import {
     AfterContentInit,
-    AfterViewInit,
     ChangeDetectorRef,
     Component,
     ContentChildren,
@@ -131,7 +130,7 @@ export type ActiveItemBackgroundShape = 'round' | 'square';
 })
 export class DrawerNavItemComponent
     extends StateListener
-    implements Omit<DrawerNavItem, 'items'>, AfterContentInit, AfterViewInit
+    implements Omit<DrawerNavItem, 'items'>, AfterContentInit
 {
     /** Sets the active item background shape
      *
@@ -220,28 +219,23 @@ export class DrawerNavItemComponent
         }
     }
 
-    ngAfterViewInit(): void {
-        this.handleExpand();
-    }
-
     ngAfterContentInit(): void {
         // If ContentChildren is self-inclusive (ng version < 9), filter self out using service-generated NavItem ID.
         this.nestedNavItems = this.nestedNavItems.filter((item: DrawerNavItemComponent) => item.id !== this.id);
     }
 
     handleExpand(): void {
-        if (!this.matExpansionPanel) {
-            return;
-        }
-
         setTimeout(() => {
-            // Persistent drawers will only expand if they the drawer is opened.
-            // Temporary drawers will always have any expansion panels opened.
-            if (this.expanded && (this.isOpen() || this.drawerService.getDrawerVariant() === 'temporary')) {
-                this.matExpansionPanel.open();
-            } else {
-                this.matExpansionPanel.close();
-            }
+          if (!this.matExpansionPanel) {
+            return;
+          }
+          // Persistent drawers will only expand if they the drawer is opened.
+          // Temporary drawers will always have any expansion panels opened.
+          if (this.expanded && (this.isOpen() || this.drawerService.getDrawerVariant() === 'temporary')) {
+            this.matExpansionPanel.open();
+          } else {
+            this.matExpansionPanel.close();
+          }
         });
     }
 
@@ -300,6 +294,9 @@ export class DrawerNavItemComponent
         }
         this.depth = parentDepth + 1;
         this.hasChildren = this.nestedNavItems && this.nestedNavItems.length > 0;
+        if (this.hasChildren && this.expanded === true) {
+          this.handleExpand();
+        }
         this.changeDetector.detectChanges();
     }
 


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #391 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Previously the `NavItem` wasn't being rendered on the screen before the initial `handleExpanded` call.  Run the `handleExpanded` logic after depth has been calculated.  
- Move the entire `handleExpanded` logic into an async fn so it runs after Drawer state has been updated. 

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Run the showcase, but set `expanded` to true on init for a selected nav group. 
