### PR TITLE
Fix app bar transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 -   Updated to Angular 13 for building the library.
 
+### Fixed
+
+-   Fixed `<blui-app-bar>` and `<blui-three-liner>` applying transition to `color` and `background-color` style properties ([#395](https://github.com/brightlayer-ui/angular-component-library/issues/395)).
+
 ## v6.0.4 (February 14, 2022)
 
 -   Fixed change detection error in `<blui-drawer-nav-item>`([#397](https://github.com/brightlayer-ui/angular-component-library/issues/397)).

--- a/components/src/core/app-bar/app-bar.component.scss
+++ b/components/src/core/app-bar/app-bar.component.scss
@@ -6,7 +6,7 @@
     z-index: 1000; /* Ensure that your app's content doesn't overlap the toolbar */
 }
 
-$transition: all .3s, color 0s, background-color 0s;
+$transition: all 0.3s, color 0s, background-color 0s;
 .blui-app-bar-content {
     min-height: unset;
     transition: $transition;

--- a/components/src/core/app-bar/app-bar.component.scss
+++ b/components/src/core/app-bar/app-bar.component.scss
@@ -6,7 +6,7 @@
     z-index: 1000; /* Ensure that your app's content doesn't overlap the toolbar */
 }
 
-$transition: all 300ms;
+$transition: all .3s, color 0s, background-color 0s;
 .blui-app-bar-content {
     min-height: unset;
     transition: $transition;

--- a/components/src/core/three-liner/three-liner.component.scss
+++ b/components/src/core/three-liner/three-liner.component.scss
@@ -1,4 +1,4 @@
-$transition: all 300ms;
+$transition: all .3s, color 0s, background-color 0s;
 
 .blui-three-liner {
     display: flex;

--- a/components/src/core/three-liner/three-liner.component.scss
+++ b/components/src/core/three-liner/three-liner.component.scss
@@ -1,4 +1,4 @@
-$transition: all .3s, color 0s, background-color 0s;
+$transition: all 0.3s, color 0s, background-color 0s;
 
 .blui-three-liner {
     display: flex;


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #395 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Remove the transition applied to `color` & `background-color` by default.

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- `yarn start:showcase` and observe the animation is no longer applied whenever the AppBar is rendered.  

http://localhost:4200/blui-components/surface-components

