### PR TITLE
Adjust toolbarmenu line height

### DIFF
--- a/components/src/core/toolbar-menu/toolbar-menu.component.scss
+++ b/components/src/core/toolbar-menu/toolbar-menu.component.scss
@@ -17,6 +17,9 @@
         align-items: center;
         cursor: pointer;
     }
+    .blui-toolbar-menu-label {
+        line-height: 1rem;
+    }
     .blui-toolbar-icon-wrapper .mat-icon {
         font-size: 1rem;
         width: 1rem;


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Fix `toolbarmenu` line height; it should be 1rem in this case. 

