### PR TITLE
Bug/2955 empty state border box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 -   Updated to Angular 13 for building the library.
 
+### Fixed
+
+-   Fixed container overflow in `<blui-empty-state>` ([#400](https://github.com/brightlayer-ui/angular-component-library/issues/400)).
 ## v6.0.4 (February 14, 2022)
 
 -   Fixed change detection error in `<blui-drawer-nav-item>`([#397](https://github.com/brightlayer-ui/angular-component-library/issues/397)).

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brightlayer-ui/angular-components",
-  "version": "7.0.0-beta.2",
+  "version": "7.0.0-beta.3",
   "description": "Angular components for Brightlayer UI applications",
   "scripts": {
     "ng": "ng",

--- a/components/src/core/empty-state/empty-state.component.scss
+++ b/components/src/core/empty-state/empty-state.component.scss
@@ -5,6 +5,7 @@
 .blui-empty-state-content {
     height: 100%;
     width: 100%;
+    box-sizing: border-box;
     padding: 1rem;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #400 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add `box-sizing:border-box` to `blui-empty-state-content`. 

This is difficult to test in the showcase app since we don't have an overflow happening there. 
To test, this could be published as a beta package and then integrated my app where the problem was occurring. 
