### PR TITLE
Feature/3093 drawer escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## v7.0.2 (Not published yet)
+
+### Fixed 
+
+-  Fixed escape key disappearing `<blui-drawer>` ([#426](https://github.com/brightlayer-ui/angular-component-library/issues/426)).
+
+
 ## v7.0.1 (April 15, 2022)
 
 ### Fixed

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brightlayer-ui/angular-components",
-  "version": "7.0.1",
+  "version": "7.0.2-beta.0",
   "description": "Angular components for Brightlayer UI applications",
   "scripts": {
     "ng": "ng",

--- a/components/src/core/drawer/drawer-layout/drawer-layout.component.ts
+++ b/components/src/core/drawer/drawer-layout/drawer-layout.component.ts
@@ -14,6 +14,7 @@ import { DrawerService } from '../service/drawer.service';
 import { StateListener } from '../state-listener.component';
 import { Direction, Directionality } from '@angular/cdk/bidi';
 import { Subscription } from 'rxjs';
+import {MatDrawerMode} from "@angular/material/sidenav";
 
 export type DrawerLayoutVariantType = 'permanent' | 'persistent' | 'temporary' | 'rail';
 
@@ -37,6 +38,7 @@ export type DrawerLayoutVariantType = 'permanent' | 'persistent' | 'temporary' |
                 [class.mat-elevation-z6]="!hasSideBorder()"
                 [style.width.rem]="isCollapsed() ? getCollapsedWidth() : toRem(width)"
                 [mode]="getMode()"
+                [disableClose]="true"
                 [opened]="isDrawerVisible()"
             >
                 <ng-content select="[blui-drawer]"></ng-content>
@@ -111,7 +113,7 @@ export class DrawerLayoutComponent extends StateListener implements AfterViewIni
         this.dirChangeSubscription.unsubscribe();
     }
 
-    getMode(): string {
+    getMode(): MatDrawerMode {
         return this.variant === 'temporary' ? 'over' : 'side';
     }
 

--- a/components/src/core/drawer/drawer-layout/drawer-layout.component.ts
+++ b/components/src/core/drawer/drawer-layout/drawer-layout.component.ts
@@ -14,7 +14,7 @@ import { DrawerService } from '../service/drawer.service';
 import { StateListener } from '../state-listener.component';
 import { Direction, Directionality } from '@angular/cdk/bidi';
 import { Subscription } from 'rxjs';
-import {MatDrawerMode} from "@angular/material/sidenav";
+import { MatDrawerMode } from '@angular/material/sidenav';
 
 export type DrawerLayoutVariantType = 'permanent' | 'persistent' | 'temporary' | 'rail';
 

--- a/components/src/core/drawer/service/drawer.service.ts
+++ b/components/src/core/drawer/service/drawer.service.ts
@@ -19,7 +19,7 @@ export class DrawerService {
 
     drawerOpenObs = new Subject<boolean>();
     drawerSelectObs = new Subject<boolean>();
-    drawerActiveItemChangeObs = new Subject<boolean>();
+    drawerActiveItemChangeObs = new Subject<void>();
     drawerNewNavItemInit = new Subject<void>();
 
     hasSideBorder(): boolean {
@@ -110,7 +110,7 @@ export class DrawerService {
         this.drawerActiveItemChangeObs.next();
     }
 
-    drawerActiveItemChanges(): Observable<boolean> {
+    drawerActiveItemChanges(): Observable<void> {
         return this.drawerActiveItemChangeObs;
     }
 


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #426 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Small change to DrawerService `drawerActiveItemChanges` return type.
- Small change to DrawerLayout `getMode` return type. 
- Escape key no longer dismisses drawer.

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- `yarn start:showcase` & try to dismiss the drawer by hitting escape; nothing should happen. 
