### PR TITLE
Fix user menu esc permanently disappearing menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Fixed 
 
--  Fixed escape key disappearing `<blui-drawer>` ([#426](https://github.com/brightlayer-ui/angular-component-library/issues/426)).
-
+- Fixed escape key permanently dismissing `<blui-drawer>` ([#426](https://github.com/brightlayer-ui/angular-component-library/issues/426)).
+- Fixed escape key permanently dismissing `<blui-user-menu>`. ([#434](https://github.com/brightlayer-ui/angular-component-library/issues/434)).
 
 ## v7.0.1 (April 15, 2022)
 

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brightlayer-ui/angular-components",
-  "version": "7.0.2-beta.0",
+  "version": "7.0.2-beta.1",
   "description": "Angular components for Brightlayer UI applications",
   "scripts": {
     "ng": "ng",

--- a/components/src/core/user-menu/user-menu.component.ts
+++ b/components/src/core/user-menu/user-menu.component.ts
@@ -78,6 +78,7 @@ import { requireInput } from '../../utils/utils';
 
         <ng-template
             cdkConnectedOverlay
+            (overlayKeydown)="dismissViaEscape($event)"
             (backdropClick)="onClickMenuBackdrop()"
             [cdkConnectedOverlayPush]="true"
             [cdkConnectedOverlayHasBackdrop]="true"
@@ -215,10 +216,14 @@ export class UserMenuComponent implements OnInit, OnChanges, OnDestroy {
             hasBackdrop: true,
         });
 
-        bottomSheetRef.afterDismissed().subscribe((openMenu: boolean) => {
+        bottomSheetRef.afterDismissed().subscribe((openMenu: boolean | undefined) => {
             this.isBottomSheetDismissing = false;
-            this.isMenuOpen = openMenu;
+            this.isMenuOpen = Boolean(openMenu);
             this._ref.detectChanges();
+        });
+
+        bottomSheetRef.keydownEvents().subscribe((key: KeyboardEvent) => {
+            this.dismissViaEscape(key);
         });
 
         bottomSheetRef.backdropClick().subscribe(() => {
@@ -226,5 +231,11 @@ export class UserMenuComponent implements OnInit, OnChanges, OnDestroy {
             this.openChange.emit(false);
             this.backdropClick.emit();
         });
+    }
+
+    dismissViaEscape(e: KeyboardEvent): void {
+        if (e && e.key && e.key.toLowerCase() === 'escape') {
+            this.openChange.emit(false);
+        }
     }
 }


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #434 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- User Menu dismisses when you hit 'esc', but is no longer dismissed forever. 

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- `yarn start:showcase` 
- open user menu 
- hit esc 
- open user menu
