### PR TITLE
Feature/3142 empty state centered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Fixed 
 
 - Fixed escape key permanently dismissing `<blui-drawer>` ([#426](https://github.com/brightlayer-ui/angular-component-library/issues/426)).
-- Fixed escape key permanently dismissing `<blui-user-menu>`. ([#434](https://github.com/brightlayer-ui/angular-component-library/issues/434)).
+- Fixed escape key permanently dismissing `<blui-user-menu>` ([#434](https://github.com/brightlayer-ui/angular-component-library/issues/434)).
+- Fixed `<blui-empty-state>` not being centered when a description is not provided ([#378](https://github.com/brightlayer-ui/angular-component-library/issues/378)).
 
 ## v7.0.1 (April 15, 2022)
 

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brightlayer-ui/angular-components",
-  "version": "7.0.2-beta.1",
+  "version": "7.0.2-beta.3",
   "description": "Angular components for Brightlayer UI applications",
   "scripts": {
     "ng": "ng",

--- a/components/src/core/empty-state/empty-state.component.html
+++ b/components/src/core/empty-state/empty-state.component.html
@@ -10,8 +10,11 @@
         <ng-content select="[blui-description]" *ngIf="!description"></ng-content>
         {{ description }}
     </p>
-    <div class="blui-empty-state-actions-wrapper"
-         [class.blui-empty-state-actions-wrapper-no-action]="!hasAction" #actionsRef>
+    <div
+        class="blui-empty-state-actions-wrapper"
+        [class.blui-empty-state-actions-wrapper-no-action]="!hasAction"
+        #actionsRef
+    >
         <ng-content select="[blui-actions]"></ng-content>
     </div>
 </div>

--- a/components/src/core/empty-state/empty-state.component.html
+++ b/components/src/core/empty-state/empty-state.component.html
@@ -10,7 +10,8 @@
         <ng-content select="[blui-description]" *ngIf="!description"></ng-content>
         {{ description }}
     </p>
-    <div class="blui-empty-state-actions-wrapper" [class.no-action]="!hasAction" #actionsRef>
+    <div class="blui-empty-state-actions-wrapper"
+         [class.blui-empty-state-actions-wrapper-no-action]="!hasAction" #actionsRef>
         <ng-content select="[blui-actions]"></ng-content>
     </div>
 </div>

--- a/components/src/core/empty-state/empty-state.component.html
+++ b/components/src/core/empty-state/empty-state.component.html
@@ -6,11 +6,11 @@
         <ng-content select="[blui-title]" *ngIf="!title"></ng-content>
         {{ title }}
     </h2>
-    <p class="blui-empty-state-description mat-subheading-2">
+    <p class="mat-subheading-2 blui-empty-state-description">
         <ng-content select="[blui-description]" *ngIf="!description"></ng-content>
         {{ description }}
     </p>
-    <div class="blui-empty-state-actions-wrapper">
+    <div class="blui-empty-state-actions-wrapper" [class.no-action]="!hasAction" #actionsRef>
         <ng-content select="[blui-actions]"></ng-content>
     </div>
 </div>

--- a/components/src/core/empty-state/empty-state.component.scss
+++ b/components/src/core/empty-state/empty-state.component.scss
@@ -36,7 +36,7 @@
 
     .blui-empty-state-actions-wrapper {
         margin-top: 1rem;
-        &.no-action {
+        &.blui-empty-state-actions-wrapper-no-action {
             margin-top: 0;
         }
     }

--- a/components/src/core/empty-state/empty-state.component.scss
+++ b/components/src/core/empty-state/empty-state.component.scss
@@ -16,10 +16,6 @@
         margin-bottom: 0;
     }
 
-    .blui-empty-state-description {
-        margin-bottom: 1rem;
-    }
-
     .blui-empty-state-title,
     .blui-empty-state-description {
         text-align: center;
@@ -35,6 +31,13 @@
             height: 100%;
             width: 100%;
             text-align: center;
+        }
+    }
+
+    .blui-empty-state-actions-wrapper {
+        margin-top: 1rem;
+        &.no-action {
+            margin-top: 0;
         }
     }
 

--- a/components/src/core/empty-state/empty-state.component.ts
+++ b/components/src/core/empty-state/empty-state.component.ts
@@ -1,5 +1,6 @@
 import {
     AfterViewInit,
+    ChangeDetectorRef,
     ChangeDetectionStrategy,
     Component,
     ElementRef,
@@ -7,7 +8,7 @@ import {
     ViewChild,
     ViewEncapsulation,
 } from '@angular/core';
-import { requireContent } from '../../utils/utils';
+import { requireContent, hasChildren } from '../../utils/utils';
 
 /**
  * [EmptyState Component](https://brightlayer-ui-components.github.io/angular/?path=/info/components-empty-state--readme)
@@ -34,8 +35,16 @@ export class EmptyStateComponent implements AfterViewInit {
     /** Used to check if an icon has been provided ngAfterViewInit */
     @ViewChild('emptyIcon') emptyIcon: ElementRef;
 
+    @ViewChild('actionsRef') actionsRef: ElementRef;
+    hasAction = false;
+
+    constructor(private readonly _ref: ChangeDetectorRef) {}
+
     ngAfterViewInit(): void {
         const required = { selector: 'emptyIcon', ref: this.emptyIcon };
         requireContent([required], this);
+
+        this.hasAction = hasChildren(this.actionsRef);
+        this._ref.detectChanges();
     }
 }

--- a/components/src/utils/utils.ts
+++ b/components/src/utils/utils.ts
@@ -25,7 +25,7 @@ export function requireContent(contentPairs: ContentPair[], component: any): voi
     });
 }
 
-function hasChildren(el: ElementRef): boolean {
+export function hasChildren(el: ElementRef): boolean {
     return el.nativeElement.children && el.nativeElement.children.length > 0;
 }
 

--- a/docs/EmptyState.md
+++ b/docs/EmptyState.md
@@ -66,11 +66,12 @@ The following child elements are projected into `<blui-empty-state>`:
 
 Each Brightlayer UI component has classes which can be used to override component styles:
 
-| Name                                | Description                              |
-| ----------------------------------- | ---------------------------------------- |
-| blui-empty-state                    | Styles applied to the tag                |
-| blui-empty-state-content            | Styles applied to the root element       |
-| blui-empty-state-empty-icon-wrapper | Styles applied to the icon container     |
-| blui-empty-state-title              | Styles applied to the title @Input       |
-| blui-empty-state-description        | Styles applied to the description @Input |
-| blui-empty-state-actions-wrapper    | Styles applied to the actions container  |
+| Name                                       | Description                                  |
+|--------------------------------------------|----------------------------------------------|
+| blui-empty-state                           | Styles applied to the tag                    |
+| blui-empty-state-content                   | Styles applied to the root element           |
+| blui-empty-state-empty-icon-wrapper        | Styles applied to the icon container         |
+| blui-empty-state-title                     | Styles applied to the title @Input           |
+| blui-empty-state-description               | Styles applied to the description @Input     |
+| blui-empty-state-actions-wrapper           | Styles applied to the actions container      |
+| blui-empty-state-actions-wrapper-no-action | Styles applied to an empty actions container | 


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #378 
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Fix Empty State not being centered when a description is not provided.
- Moves description margin onto the actions-wrapper, then apply a conditional style to remove margin if no action. 

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Run the showcase & observe the empty state is perfectly centered in all 3 empty state examples.
- http://localhost:4200/blui-components/data-display-components

<img width="408" alt="Screen Shot 2022-05-23 at 10 34 13 AM" src="https://user-images.githubusercontent.com/6538289/169843323-aebf9592-317e-4dda-8a35-ca661eb85303.png">
