### PR TITLE
Feature/3144 drawer transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed escape key permanently dismissing `<blui-drawer>` ([#426](https://github.com/brightlayer-ui/angular-component-library/issues/426)).
 - Fixed escape key permanently dismissing `<blui-user-menu>`. ([#434](https://github.com/brightlayer-ui/angular-component-library/issues/434)).
+- Fixed `<blui-drawer-layout>` opening side nav when transitioning to a `temporary` state ([#82](https://github.com/brightlayer-ui/angular-component-library/issues/82)).
 
 ## v7.0.1 (April 15, 2022)
 

--- a/components/src/core/drawer/drawer-layout/drawer-layout.component.ts
+++ b/components/src/core/drawer/drawer-layout/drawer-layout.component.ts
@@ -83,7 +83,10 @@ export class DrawerLayoutComponent extends StateListener implements AfterViewIni
     @ViewChild('remElement') remElement: ElementRef;
 
     isRtl = false;
-    hasTransitionedToTemporary = false;
+
+    /** This is true whenever the drawer is in a collapsed state & its variant has been transitioned to temporary. */
+    hasCollapsedTransitionToTemporary = false;
+
     remSizePx: number;
     dirChangeSubscription = Subscription.EMPTY;
 
@@ -116,9 +119,9 @@ export class DrawerLayoutComponent extends StateListener implements AfterViewIni
                 variant.currentValue === 'temporary' &&
                 (variant.previousValue === 'rail' || (variant.previousValue === 'persistent' && !this.isOpen()))
             ) {
-                this.hasTransitionedToTemporary = true;
+                this.hasCollapsedTransitionToTemporary = true;
                 setTimeout(() => {
-                    this.hasTransitionedToTemporary = false;
+                    this.hasCollapsedTransitionToTemporary = false;
                 }, 500);
             }
         }
@@ -175,7 +178,7 @@ export class DrawerLayoutComponent extends StateListener implements AfterViewIni
     isCollapsed(): boolean {
         if (this.variant === 'rail') return true; // Rail is always collapsed.
         if (this.variant === 'persistent') return !this.isOpen();
-        if (this.hasTransitionedToTemporary) return true;
+        if (this.hasCollapsedTransitionToTemporary) return true;
         return false;
     }
 }


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #82 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Fixes drawer jankiness when closing drawer.

This bug was happening because the drawer width was being recalculated on `variant` change.

In the `drawer-layout.component.ts` file...

When the variant is updated to `temporary`, the width of the drawer is quickly recalculated to it's full, non-collapsed size.  This is because `isCollapsed()` was returning `false` after the variant was updated to `temporary`.  
I've added in an edge-case that listens for this change & if the drawer is in a collapsed state, avoids the recalculated width until the drawer is fully dismissed from the screen. 

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![Drawer Dismissable](https://user-images.githubusercontent.com/6538289/169891294-6322499c-5e55-479c-98e6-2e9545681e9a.gif)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Checkout the showcase project and adjust the size of the screen width until it transitions from a `persistent` to `temporary` variant.  Try this for when the drawer is opened & closed. 

This also should be checked for the `rail` variant.  
