### PR TITLE
feat: Add IDs to user-menu-header title and subtitle

### DIFF
--- a/components/src/core/user-menu/user-menu-header/user-menu-header.component.ts
+++ b/components/src/core/user-menu/user-menu-header/user-menu-header.component.ts
@@ -21,8 +21,8 @@ import { isEmptyView } from '../../../utils/utils';
                     <ng-content select="[blui-icon]"></ng-content>
                 </div>
                 <div *ngIf="title" class="blui-user-menu-header-title-wrapper">
-                    <div class="blui-user-menu-header-title">{{ title }}</div>
-                    <div *ngIf="subtitle" class="blui-user-menu-header-subtitle mat-subheading-2">{{ subtitle }}</div>
+                    <div id="{{id}}-title" class="blui-user-menu-header-title">{{ title }}</div>
+                    <div *ngIf="subtitle" id="{{id}}-subtitle" class="blui-user-menu-header-subtitle mat-subheading-2">{{ subtitle }}</div>
                 </div>
                 <ng-content select="[blui-title-content]"></ng-content>
             </div>
@@ -49,6 +49,8 @@ export class UserMenuHeaderComponent {
     @Input() subtitle: string;
     /** The text to show on the first line */
     @Input() title: string;
+    /** Menu id */
+    @Input() id: string;
 
     @ViewChild('icon', { static: true }) iconEl: ElementRef;
 

--- a/components/src/core/user-menu/user-menu.component.ts
+++ b/components/src/core/user-menu/user-menu.component.ts
@@ -105,10 +105,10 @@ export class UserMenuComponent implements OnInit, OnChanges, OnDestroy {
     @Input() avatarValue: string;
 
     /** Subtitle shown when menu is open */
-    @Input() menuSubtitle: string;
+    @Input() menuSubtitle: string | TemplateRef<any>;
 
     /** Title shown when menu is open */
-    @Input() menuTitle: string;
+    @Input() menuTitle: string | TemplateRef<any>;
 
     /** Where to render the menu relative to the avatar */
     @Input() positions = [

--- a/components/src/core/user-menu/user-menu.component.ts
+++ b/components/src/core/user-menu/user-menu.component.ts
@@ -59,6 +59,7 @@ import { requireInput } from '../../utils/utils';
             <blui-user-menu-header
                 *ngIf="menuTitle"
                 class="blui-user-menu-header"
+                id="id"
                 [title]="menuTitle"
                 [subtitle]="menuSubtitle"
                 [divider]="true"
@@ -105,10 +106,10 @@ export class UserMenuComponent implements OnInit, OnChanges, OnDestroy {
     @Input() avatarValue: string;
 
     /** Subtitle shown when menu is open */
-    @Input() menuSubtitle: string | TemplateRef<any>;
+    @Input() menuSubtitle: string;
 
     /** Title shown when menu is open */
-    @Input() menuTitle: string | TemplateRef<any>;
+    @Input() menuTitle: string;
 
     /** Where to render the menu relative to the avatar */
     @Input() positions = [

--- a/demos/storybook/stories/user-menu/with-menu-header.stories.ts
+++ b/demos/storybook/stories/user-menu/with-menu-header.stories.ts
@@ -5,7 +5,8 @@ import { invertRTL } from '../../src/utils';
 export const withMenuHeader = (): any => ({
     template: `
         <blui-user-menu 
-            avatarValue="AV" 
+            avatarValue="AV"
+            [id]="id"
             [menuTitle]="menuTitle" 
             [menuSubtitle]="menuSubtitle"
             [(open)]="open">
@@ -21,6 +22,7 @@ export const withMenuHeader = (): any => ({
     props: {
         open: false,
         items: items,
+        id: 'my-awesome-menu',
         menuTitle: text('menuTitle', 'Sample Title'),
         menuSubtitle: text('menuSubtitle', 'Sample subtitle'),
         invertRTL: invertRTL,


### PR DESCRIPTION
Changes proposed in this Pull Request:
- Type both menuTitle and menuSbutitle as string | TemplateRef to have an easier way for customizing User menu header