### PR TITLE
Start adding copy generated code snippet button and knob sections

### DIFF
--- a/src/docs/navigation/navigation.component.html
+++ b/src/docs/navigation/navigation.component.html
@@ -5,7 +5,6 @@
             <blui-drawer-nav-group>
                 <blui-drawer-nav-item
                     *ngFor="let navItem of navItems"
-                    [divider]="true"
                     [title]="navItem.title"
                     [selected]="navItem.title === getSelectedItem()"
                     (select)="selectItem(navItem)"
@@ -16,7 +15,6 @@
             <blui-drawer-nav-group title="Components" [divider]="false">
                 <blui-drawer-nav-item
                     *ngFor="let navItem of componentNavItems"
-                    [divider]="true"
                     [title]="navItem.title"
                     [hidePadding]="true"
                     [selected]="navItem.title === getSelectedItem()"
@@ -35,7 +33,7 @@
         </blui-drawer-body>
     </blui-drawer>
     <div blui-content class="drawer-content">
-        <mat-toolbar class="toolbar" color="primary">
+        <mat-toolbar class="toolbar">
             <button
                 mat-icon-button
                 *ngIf="variant === 'temporary'"

--- a/src/docs/pages/component-docs/components/drawer/drawer-body/drawer-body-doc.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-body/drawer-body-doc.component.ts
@@ -5,7 +5,7 @@ import { MarkdownService } from 'ngx-markdown';
 @Component({
     selector: 'app-drawer-body-doc',
     template: `
-        <app-component-doc-scaffold [md]="md">
+        <app-component-doc-scaffold [md]="md" [hasExamples]="false" [hasPlayground]="false">
             <div examples>
                 <app-coming-soon></app-coming-soon>
             </div>

--- a/src/docs/pages/component-docs/components/drawer/drawer-footer/drawer-footer-doc.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-footer/drawer-footer-doc.component.ts
@@ -8,7 +8,7 @@ import { SubheaderPlaygroundKnobs } from '../drawer-subheader/examples/playgroun
 @Component({
     selector: 'app-drawer-footer-doc',
     template: `
-        <app-component-doc-scaffold [md]="md" [knobs]="knobs">
+        <app-component-doc-scaffold [md]="md" [knobGroups]="knobGroups">
             <div examples class="app-example">
                 <div class="example-section">
                     <div class="example-heading">Basic Drawer Footer</div>
@@ -41,7 +41,7 @@ import { SubheaderPlaygroundKnobs } from '../drawer-subheader/examples/playgroun
                 [inputs]="knobs"
                 (codeChange)="generatedCode = $event"
             ></app-footer-playground>
-            <app-example-code code [snippet]="generatedCode"></app-example-code>
+            <app-example-code code [snippet]="generatedCode" [copyButtonOnHover]="true"></app-example-code>
         </app-component-doc-scaffold>
     `,
     styleUrls: ['./drawer-footer-doc.component.scss'],
@@ -67,6 +67,13 @@ export class DrawerFooterDocComponent {
             hint: 'Hide content when the drawer is collapsed',
         },
     };
+    knobGroups = [
+        {
+            title: 'Properties',
+            knobs: this.knobs,
+            defaultExpanded: true,
+        },
+    ];
 
     constructor(
         private readonly _splitService: MarkdownSplitService,

--- a/src/docs/pages/component-docs/components/drawer/drawer-footer/drawer-footer-doc.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-footer/drawer-footer-doc.component.ts
@@ -69,7 +69,7 @@ export class DrawerFooterDocComponent {
     };
     knobGroups = [
         {
-            title: 'Properties',
+            title: 'Optional Props',
             knobs: this.knobs,
             defaultExpanded: true,
         },

--- a/src/docs/pages/component-docs/components/drawer/drawer-footer/drawer-footer-doc.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-footer/drawer-footer-doc.component.ts
@@ -69,7 +69,7 @@ export class DrawerFooterDocComponent {
     };
     knobGroups = [
         {
-            title: 'Optional Props',
+            title: 'Optional Properties',
             knobs: this.knobs,
             defaultExpanded: true,
         },

--- a/src/docs/pages/component-docs/components/drawer/drawer-footer/drawer-footer-doc.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-footer/drawer-footer-doc.component.ts
@@ -3,7 +3,7 @@ import { MarkdownService } from 'ngx-markdown';
 import { MarkdownSplitService } from '../../../../../services/markdown-split/markdown-split.service';
 import { BASIC } from './examples/basic.component';
 import { COMPLEX } from './examples/complex.component';
-import { SubheaderPlaygroundKnobs } from '../drawer-subheader/examples/playground.component';
+import { DrawerFooterPlaygroundKnobs } from './examples/playground.component';
 
 @Component({
     selector: 'app-drawer-footer-doc',
@@ -53,7 +53,7 @@ export class DrawerFooterDocComponent {
     generatedCode: string;
 
     /* Default playground knobs */
-    knobs: SubheaderPlaygroundKnobs = {
+    knobs: DrawerFooterPlaygroundKnobs = {
         divider: {
             value: true,
             componentDefault: true,

--- a/src/docs/pages/component-docs/components/drawer/drawer-footer/examples/playground.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-footer/examples/playground.component.ts
@@ -39,14 +39,12 @@ export class PlaygroundComponent implements OnDestroy {
     constructor(private readonly _playgroundService: PlaygroundService) {
         this.knobListener = this._playgroundService.knobChange.subscribe((updatedKnobs: SubheaderPlaygroundKnobs) => {
             this.inputs = updatedKnobs;
-            this.codeChange.emit(this._createGeneratedCode());
+            this._emitNewCodeChanges();
         });
     }
 
     ngAfterViewInit(): void {
-        setTimeout(() => {
-            this.codeChange.emit(this._createGeneratedCode());
-        });
+        this._emitNewCodeChanges();
     }
 
     ngOnDestroy(): void {
@@ -58,6 +56,12 @@ export class PlaygroundComponent implements OnDestroy {
     toggleDrawer(): void {
         this.open = !this.open;
         this.codeChange.emit(this._createGeneratedCode());
+    }
+
+    private _emitNewCodeChanges(): void {
+        setTimeout(() => {
+            this.codeChange.emit(this._createGeneratedCode());
+        });
     }
 
     private _createGeneratedCode(): string {

--- a/src/docs/pages/component-docs/components/drawer/drawer-footer/examples/playground.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-footer/examples/playground.component.ts
@@ -3,7 +3,7 @@ import { PlaygroundService } from '../../../../../../services/playground/playgro
 import { Subscription } from 'rxjs';
 import { Knob } from '../../../../shared/scaffold/scaffold.component';
 
-export type SubheaderPlaygroundKnobs = {
+export type DrawerFooterPlaygroundKnobs = {
     divider: Knob;
     hideContentOnCollapse: Knob;
 };
@@ -30,17 +30,19 @@ export type SubheaderPlaygroundKnobs = {
     </blui-drawer>`,
 })
 export class PlaygroundComponent implements OnDestroy {
-    @Input() inputs: SubheaderPlaygroundKnobs;
+    @Input() inputs: DrawerFooterPlaygroundKnobs;
     @Output() codeChange = new EventEmitter<string>();
 
     open = true;
     knobListener: Subscription;
 
     constructor(private readonly _playgroundService: PlaygroundService) {
-        this.knobListener = this._playgroundService.knobChange.subscribe((updatedKnobs: SubheaderPlaygroundKnobs) => {
-            this.inputs = updatedKnobs;
-            this._emitNewCodeChanges();
-        });
+        this.knobListener = this._playgroundService.knobChange.subscribe(
+            (updatedKnobs: DrawerFooterPlaygroundKnobs) => {
+                this.inputs = updatedKnobs;
+                this._emitNewCodeChanges();
+            }
+        );
     }
 
     ngAfterViewInit(): void {

--- a/src/docs/pages/component-docs/components/drawer/drawer-header/drawer-header-doc.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-header/drawer-header-doc.component.ts
@@ -10,7 +10,7 @@ import { HeaderPlaygroundKnobs } from './examples/playground.component';
 @Component({
     selector: 'app-drawer-header-doc',
     template: `
-        <app-component-doc-scaffold [md]="md" [knobs]="knobs">
+        <app-component-doc-scaffold [md]="md" [knobs]="knobs" [knobGroups]="knobGroups">
             <div examples class="app-example">
                 <div class="example-section">
                     <div class="example-heading">Basic Drawer Header</div>
@@ -125,6 +125,14 @@ export class DrawerHeaderDocComponent {
             hint: 'Show a header icon',
         },
     };
+    knobGroups = [
+        {
+            title: 'Required',
+            knobs: this.knobs,
+            defaultExpanded: true,
+        }
+    ]
+
 
     constructor(
         private readonly _splitService: MarkdownSplitService,

--- a/src/docs/pages/component-docs/components/drawer/drawer-header/drawer-header-doc.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-header/drawer-header-doc.component.ts
@@ -80,7 +80,7 @@ import { HeaderPlaygroundKnobs } from './examples/playground.component';
                 [inputs]="knobs"
                 (codeChange)="generatedCode = $event"
             ></app-header-playground>
-            <app-example-code code [snippet]="generatedCode"></app-example-code>
+            <app-example-code code [snippet]="generatedCode" [copyButtonOnHover]="true"></app-example-code>
         </app-component-doc-scaffold>
     `,
     styleUrls: ['./drawer-header-doc.component.scss'],

--- a/src/docs/pages/component-docs/components/drawer/drawer-header/drawer-header-doc.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-header/drawer-header-doc.component.ts
@@ -130,9 +130,8 @@ export class DrawerHeaderDocComponent {
             title: 'Required',
             knobs: this.knobs,
             defaultExpanded: true,
-        }
-    ]
-
+        },
+    ];
 
     constructor(
         private readonly _splitService: MarkdownSplitService,

--- a/src/docs/pages/component-docs/components/drawer/drawer-header/drawer-header-doc.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-header/drawer-header-doc.component.ts
@@ -10,7 +10,7 @@ import { HeaderPlaygroundKnobs } from './examples/playground.component';
 @Component({
     selector: 'app-drawer-header-doc',
     template: `
-        <app-component-doc-scaffold [md]="md" [knobs]="knobs" [knobGroups]="knobGroups">
+        <app-component-doc-scaffold [md]="md" [knobGroups]="knobGroups">
             <div examples class="app-example">
                 <div class="example-section">
                     <div class="example-heading">Basic Drawer Header</div>
@@ -127,7 +127,7 @@ export class DrawerHeaderDocComponent {
     };
     knobGroups = [
         {
-            title: 'Required',
+            title: 'Properties',
             knobs: this.knobs,
             defaultExpanded: true,
         },

--- a/src/docs/pages/component-docs/components/drawer/drawer-header/drawer-header-doc.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-header/drawer-header-doc.component.ts
@@ -77,7 +77,7 @@ import { HeaderPlaygroundKnobs } from './examples/playground.component';
             </div>
             <app-header-playground
                 playground
-                [inputs]="knobs"
+                [inputs]="allProps"
                 (codeChange)="generatedCode = $event"
             ></app-header-playground>
             <app-example-code code [snippet]="generatedCode" [copyButtonOnHover]="true"></app-example-code>
@@ -94,7 +94,7 @@ export class DrawerHeaderDocComponent {
     generatedCode: string;
 
     /* Default playground knobs */
-    knobs: HeaderPlaygroundKnobs = {
+    optionalProps: Partial<HeaderPlaygroundKnobs> = {
         title: {
             value: 'title',
             type: 'string',
@@ -117,19 +117,27 @@ export class DrawerHeaderDocComponent {
             type: 'boolean',
             hint: 'Show divider under header',
         },
+    };
+    otherProps: Partial<HeaderPlaygroundKnobs> = {
         showIcon: {
-            label: 'Show Icon',
+            label: 'Add Icon',
             value: true,
             componentDefault: false,
             type: 'boolean',
             hint: 'Show a header icon',
         },
     };
+    allProps = Object.assign({}, this.otherProps, this.optionalProps);
     knobGroups = [
         {
-            title: 'Optional Props',
-            knobs: this.knobs,
+            title: 'Optional Properties',
+            knobs: this.optionalProps,
             defaultExpanded: true,
+        },
+        {
+            title: 'Other Properties',
+            knobs: this.otherProps,
+            defaultExpanded: false,
         },
     ];
 

--- a/src/docs/pages/component-docs/components/drawer/drawer-header/drawer-header-doc.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-header/drawer-header-doc.component.ts
@@ -127,7 +127,7 @@ export class DrawerHeaderDocComponent {
     };
     knobGroups = [
         {
-            title: 'Properties',
+            title: 'Optional Props',
             knobs: this.knobs,
             defaultExpanded: true,
         },

--- a/src/docs/pages/component-docs/components/drawer/drawer-header/examples/playground.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-header/examples/playground.component.ts
@@ -13,7 +13,7 @@ export type HeaderPlaygroundKnobs = {
 
 @Component({
     selector: 'app-header-playground',
-    template: ` <blui-drawer style="width: 250px">
+    template: ` <blui-drawer>
         <blui-drawer-header
             [color]="inputs.color.value"
             [divider]="inputs.divider.value"
@@ -84,7 +84,7 @@ export class PlaygroundComponent implements OnDestroy {
 
     private _createGeneratedCode(): string {
         const code = `
-<blui-drawer style="width: 250px">
+<blui-drawer>
     <blui-drawer-header
         ${this._playgroundService.addOptionalProp(this.inputs, 'title')}
         ${this._playgroundService.addOptionalProp(this.inputs, 'subtitle')}

--- a/src/docs/pages/component-docs/components/drawer/drawer-header/examples/playground.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-header/examples/playground.component.ts
@@ -43,20 +43,24 @@ export class PlaygroundComponent implements OnDestroy {
     constructor(private readonly _playgroundService: PlaygroundService) {
         this.knobListener = this._playgroundService.knobChange.subscribe((updatedKnobs: HeaderPlaygroundKnobs) => {
             this.inputs = updatedKnobs;
-            this.codeChange.emit(this._createGeneratedCode());
+            this._emitNewCodeChanges();
         });
     }
 
     ngAfterViewInit(): void {
-        setTimeout(() => {
-            this.codeChange.emit(this._createGeneratedCode());
-        });
+        this._emitNewCodeChanges();
     }
 
     ngOnDestroy(): void {
         if (this.knobListener) {
             this.knobListener.unsubscribe();
         }
+    }
+
+    private _emitNewCodeChanges(): void {
+        setTimeout(() => {
+            this.codeChange.emit(this._createGeneratedCode());
+        });
     }
 
     private _getMenuIcon(): string {
@@ -68,19 +72,6 @@ export class PlaygroundComponent implements OnDestroy {
         }
         return '';
     }
-
-    /*
-    private _getCustomHeaderContent(): string {
-        if (this.inputs.showCustomContent.value) {
-            return `
-        <div blui-title-content>
-            <div class="mat-h4" style="margin: 12px 0 -8px 0">Customizable</div>
-            <div class="mat-h2" style="margin: 0">Header Content</div>
-        </div>`;
-        }
-        return '';
-    }
-    */
 
     private _createGeneratedCode(): string {
         const code = `

--- a/src/docs/pages/component-docs/components/drawer/drawer-nav-group/drawer-nav-group-doc.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-nav-group/drawer-nav-group-doc.component.ts
@@ -75,7 +75,7 @@ import { CUSTOM_CONTENT } from './examples/with-custom-content.component';
                 [inputs]="knobs"
                 (codeChange)="generatedCode = $event"
             ></app-nav-group-playground>
-            <app-example-code code [snippet]="generatedCode"></app-example-code>
+            <app-example-code code [snippet]="generatedCode" [copyButtonOnHover]="true"></app-example-code>
         </app-component-doc-scaffold>
     `,
     styleUrls: ['./drawer-nav-group-doc.component.scss'],

--- a/src/docs/pages/component-docs/components/drawer/drawer-nav-group/drawer-nav-group-doc.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-nav-group/drawer-nav-group-doc.component.ts
@@ -105,7 +105,7 @@ export class DrawerNavGroupDocComponent {
     };
     knobGroups = [
         {
-            title: 'Properties',
+            title: 'Optional Props',
             knobs: this.knobs,
             defaultExpanded: true,
         },

--- a/src/docs/pages/component-docs/components/drawer/drawer-nav-group/drawer-nav-group-doc.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-nav-group/drawer-nav-group-doc.component.ts
@@ -10,7 +10,7 @@ import { CUSTOM_CONTENT } from './examples/with-custom-content.component';
 @Component({
     selector: 'app-drawer-nav-group-doc',
     template: `
-        <app-component-doc-scaffold [md]="md" [knobs]="knobs">
+        <app-component-doc-scaffold [md]="md" [knobGroups]="knobGroups">
             <div examples class="app-example">
                 <div class="example-section">
                     <div class="example-heading">Basic Drawer Nav Group</div>
@@ -103,6 +103,13 @@ export class DrawerNavGroupDocComponent {
             hint: 'Divider that appears under the title',
         },
     };
+    knobGroups = [
+        {
+            title: 'Properties',
+            knobs: this.knobs,
+            defaultExpanded: true,
+        },
+    ];
 
     constructor(
         private readonly _splitService: MarkdownSplitService,

--- a/src/docs/pages/component-docs/components/drawer/drawer-nav-group/drawer-nav-group-doc.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-nav-group/drawer-nav-group-doc.component.ts
@@ -105,7 +105,7 @@ export class DrawerNavGroupDocComponent {
     };
     knobGroups = [
         {
-            title: 'Optional Props',
+            title: 'Optional Properties',
             knobs: this.knobs,
             defaultExpanded: true,
         },

--- a/src/docs/pages/component-docs/components/drawer/drawer-nav-item/drawer-nav-item-doc.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-nav-item/drawer-nav-item-doc.component.ts
@@ -168,7 +168,7 @@ export class DrawerNavItemDocComponent {
     };
     knobGroups = [
         {
-            title: 'Properties',
+            title: 'Optional Props',
             knobs: this.knobs,
             defaultExpanded: true,
         },

--- a/src/docs/pages/component-docs/components/drawer/drawer-nav-item/drawer-nav-item-doc.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-nav-item/drawer-nav-item-doc.component.ts
@@ -10,7 +10,7 @@ import { NavItemPlaygroundKnobs } from './examples/playground.component';
 @Component({
     selector: 'app-drawer-nav-item-doc',
     template: `
-        <app-component-doc-scaffold [md]="md" [knobs]="knobs">
+        <app-component-doc-scaffold [md]="md" [knobGroups]="knobGroups">
             <div examples class="app-example">
                 <div class="example-section">
                     <div class="example-heading">Basic Drawer Nav Items</div>
@@ -86,7 +86,7 @@ import { NavItemPlaygroundKnobs } from './examples/playground.component';
                 [inputs]="knobs"
                 (codeChange)="generatedCode = $event"
             ></app-nav-item-playground>
-            <app-example-code code [snippet]="generatedCode"></app-example-code>
+            <app-example-code code [snippet]="generatedCode" [copyButtonOnHover]="true"></app-example-code>
         </app-component-doc-scaffold>
     `,
     styleUrls: ['./drawer-nav-item-doc.component.scss'],
@@ -166,6 +166,13 @@ export class DrawerNavItemDocComponent {
             hint: 'Mark selected item as active',
         },
     };
+    knobGroups = [
+        {
+            title: 'Properties',
+            knobs: this.knobs,
+            defaultExpanded: true,
+        },
+    ];
 
     constructor(
         private readonly _splitService: MarkdownSplitService,

--- a/src/docs/pages/component-docs/components/drawer/drawer-nav-item/drawer-nav-item-doc.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-nav-item/drawer-nav-item-doc.component.ts
@@ -165,13 +165,6 @@ export class DrawerNavItemDocComponent {
             type: 'boolean',
             hint: 'Mark selected item as active',
         },
-        slide: {
-            value: 20,
-            componentDefault: 20,
-            range: { min: 10, max: 50 },
-            type: 'number',
-            hint: 'Mark selected item as active',
-        },
     };
     knobGroups = [
         {

--- a/src/docs/pages/component-docs/components/drawer/drawer-nav-item/drawer-nav-item-doc.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-nav-item/drawer-nav-item-doc.component.ts
@@ -83,7 +83,7 @@ import { NavItemPlaygroundKnobs } from './examples/playground.component';
             </div>
             <app-nav-item-playground
                 playground
-                [inputs]="knobs"
+                [inputs]="allProps"
                 (codeChange)="generatedCode = $event"
             ></app-nav-item-playground>
             <app-example-code code [snippet]="generatedCode" [copyButtonOnHover]="true"></app-example-code>
@@ -100,7 +100,7 @@ export class DrawerNavItemDocComponent {
     generatedCode: string;
 
     /* Default playground knobs */
-    knobs: NavItemPlaygroundKnobs = {
+    optionalKnobs: Partial<NavItemPlaygroundKnobs> = {
         title: {
             value: 'title',
             type: 'string',
@@ -122,13 +122,6 @@ export class DrawerNavItemDocComponent {
             type: 'select',
             options: ['square', 'round'],
             hint: 'Selected item background highlight',
-        },
-        addIcon: {
-            label: 'Add Icon',
-            value: false,
-            componentDefault: false,
-            type: 'boolean',
-            hint: 'Render a navigation icon',
         },
         chevron: {
             value: true,
@@ -166,11 +159,26 @@ export class DrawerNavItemDocComponent {
             hint: 'Mark selected item as active',
         },
     };
+    otherKnobs: Partial<NavItemPlaygroundKnobs> = {
+        addIcon: {
+            label: 'Add Icon',
+            value: false,
+            componentDefault: false,
+            type: 'boolean',
+            hint: 'Render a navigation icon',
+        },
+    };
+    allProps = Object.assign({}, this.otherKnobs, this.optionalKnobs);
     knobGroups = [
         {
-            title: 'Optional Props',
-            knobs: this.knobs,
+            title: 'Optional Properties',
+            knobs: this.optionalKnobs,
             defaultExpanded: true,
+        },
+        {
+            title: 'Other Properties',
+            knobs: this.otherKnobs,
+            defaultExpanded: false,
         },
     ];
 

--- a/src/docs/pages/component-docs/components/drawer/drawer-nav-item/drawer-nav-item-doc.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-nav-item/drawer-nav-item-doc.component.ts
@@ -165,6 +165,13 @@ export class DrawerNavItemDocComponent {
             type: 'boolean',
             hint: 'Mark selected item as active',
         },
+        slide: {
+            value: 20,
+            componentDefault: 20,
+            range: { min: 10, max: 50 },
+            type: 'number',
+            hint: 'Mark selected item as active',
+        },
     };
     knobGroups = [
         {

--- a/src/docs/pages/component-docs/components/drawer/drawer-nav-item/examples/playground.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-nav-item/examples/playground.component.ts
@@ -15,8 +15,6 @@ export type NavItemPlaygroundKnobs = {
     statusColor: Knob;
     addIcon: Knob;
     selected: Knob;
-
-    slide: Knob; // test
 };
 
 @Component({

--- a/src/docs/pages/component-docs/components/drawer/drawer-nav-item/examples/playground.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-nav-item/examples/playground.component.ts
@@ -51,20 +51,24 @@ export class PlaygroundComponent implements OnDestroy {
     constructor(private readonly _playgroundService: PlaygroundService) {
         this.knobListener = this._playgroundService.knobChange.subscribe((updatedKnobs: NavItemPlaygroundKnobs) => {
             this.inputs = updatedKnobs;
-            this.codeChange.emit(this._createGeneratedCode());
+            this._emitNewCodeChanges();
         });
     }
 
     ngAfterViewInit(): void {
-        setTimeout(() => {
-            this.codeChange.emit(this._createGeneratedCode());
-        });
+        this._emitNewCodeChanges();
     }
 
     ngOnDestroy(): void {
         if (this.knobListener) {
             this.knobListener.unsubscribe();
         }
+    }
+
+    private _emitNewCodeChanges(): void {
+        setTimeout(() => {
+            this.codeChange.emit(this._createGeneratedCode());
+        });
     }
 
     private _addOptionalMenuIcon(): string {

--- a/src/docs/pages/component-docs/components/drawer/drawer-nav-item/examples/playground.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-nav-item/examples/playground.component.ts
@@ -15,6 +15,8 @@ export type NavItemPlaygroundKnobs = {
     statusColor: Knob;
     addIcon: Knob;
     selected: Knob;
+
+    slide: Knob; // test
 };
 
 @Component({

--- a/src/docs/pages/component-docs/components/drawer/drawer-nav-item/examples/playground.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-nav-item/examples/playground.component.ts
@@ -19,7 +19,7 @@ export type NavItemPlaygroundKnobs = {
 
 @Component({
     selector: 'app-nav-item-playground',
-    template: ` <blui-drawer style="width: 250px" *ngIf="inputs">
+    template: ` <blui-drawer *ngIf="inputs">
         <blui-drawer-body>
             <blui-drawer-nav-group>
                 <blui-drawer-nav-item
@@ -73,7 +73,7 @@ export class PlaygroundComponent implements OnDestroy {
 
     private _createGeneratedCode(): string {
         const code = `
-<blui-drawer style="width: 250px">
+<blui-drawer>
     <blui-drawer-body>
         <blui-drawer-nav-group>
             <blui-drawer-nav-item 

--- a/src/docs/pages/component-docs/components/drawer/drawer-subheader/drawer-subheader-doc.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-subheader/drawer-subheader-doc.component.ts
@@ -7,7 +7,7 @@ import { SubheaderPlaygroundKnobs } from './examples/playground.component';
 
 @Component({
     selector: 'app-subheader-body-doc',
-    template: `<app-component-doc-scaffold [md]="md" [knobs]="knobs">
+    template: `<app-component-doc-scaffold [md]="md" [knobGroups]="knobGroups">
         <div examples class="app-example">
             <div class="example-section">
                 <div class="example-heading">Basic Drawer Subheader</div>
@@ -71,6 +71,13 @@ export class DrawerSubheaderDocComponent {
             hint: 'Hide content when the drawer is collapsed',
         },
     };
+    knobGroups = [
+        {
+            title: 'Properties',
+            knobs: this.knobs,
+            defaultExpanded: true,
+        },
+    ];
 
     constructor(
         private readonly _splitService: MarkdownSplitService,

--- a/src/docs/pages/component-docs/components/drawer/drawer-subheader/drawer-subheader-doc.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-subheader/drawer-subheader-doc.component.ts
@@ -73,7 +73,7 @@ export class DrawerSubheaderDocComponent {
     };
     knobGroups = [
         {
-            title: 'Properties',
+            title: 'Optional Props',
             knobs: this.knobs,
             defaultExpanded: true,
         },

--- a/src/docs/pages/component-docs/components/drawer/drawer-subheader/drawer-subheader-doc.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-subheader/drawer-subheader-doc.component.ts
@@ -46,7 +46,7 @@ import { SubheaderPlaygroundKnobs } from './examples/playground.component';
             [inputs]="knobs"
             (codeChange)="generatedCode = $event"
         ></app-subheader-playground>
-        <app-example-code code [snippet]="generatedCode"></app-example-code>
+        <app-example-code code [snippet]="generatedCode" [copyButtonOnHover]="true"></app-example-code>
     </app-component-doc-scaffold> `,
     styleUrls: ['./drawer-subheader-doc.component.scss'],
 })

--- a/src/docs/pages/component-docs/components/drawer/drawer-subheader/drawer-subheader-doc.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-subheader/drawer-subheader-doc.component.ts
@@ -73,7 +73,7 @@ export class DrawerSubheaderDocComponent {
     };
     knobGroups = [
         {
-            title: 'Optional Props',
+            title: 'Optional Properties',
             knobs: this.knobs,
             defaultExpanded: true,
         },

--- a/src/docs/pages/component-docs/components/drawer/drawer-subheader/examples/playground.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer-subheader/examples/playground.component.ts
@@ -34,14 +34,12 @@ export class PlaygroundComponent implements OnDestroy {
     constructor(private readonly _playgroundService: PlaygroundService) {
         this.knobListener = this._playgroundService.knobChange.subscribe((updatedKnobs: SubheaderPlaygroundKnobs) => {
             this.inputs = updatedKnobs;
-            this.codeChange.emit(this._createGeneratedCode());
+            this._emitNewCodeChanges();
         });
     }
 
     ngAfterViewInit(): void {
-        setTimeout(() => {
-            this.codeChange.emit(this._createGeneratedCode());
-        });
+        this._emitNewCodeChanges();
     }
 
     ngOnDestroy(): void {
@@ -53,6 +51,12 @@ export class PlaygroundComponent implements OnDestroy {
     toggleDrawer(): void {
         this.open = !this.open;
         this.codeChange.emit(this._createGeneratedCode());
+    }
+
+    private _emitNewCodeChanges(): void {
+        setTimeout(() => {
+            this.codeChange.emit(this._createGeneratedCode());
+        });
     }
 
     private _createGeneratedCode(): string {

--- a/src/docs/pages/component-docs/components/drawer/drawer/drawer-doc.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer/drawer-doc.component.ts
@@ -4,25 +4,20 @@ import { MarkdownService } from 'ngx-markdown';
 import { BASIC } from './examples/basic.component';
 import { ANATOMY } from './examples/anatomy.component';
 import { DRAWER_NAV_ITEMS } from '../../../../../navigation/nav-items';
-import { TabName } from '../../../shared/scaffold/scaffold.component';
 import { FROM_LIST } from './examples/from-list.component';
+import { DrawerPlaygroundKnobs } from './examples/playground.component';
+import { TabName } from '../../../shared/scaffold/scaffold.component';
 
 @Component({
     selector: 'app-drawer-doc',
     template: `
-        <app-component-doc-scaffold [md]="md">
+        <app-component-doc-scaffold [md]="md" [knobGroups]="knobGroups">
             <div examples class="app-example">
                 <div class="example-section">
                     <div class="example-heading">Basic Drawer</div>
                     <div class="example-description">
                         A <code>&lt;blui-drawer&gt;</code> is a navigation menu that appears to the side of an
                         application.
-                        <!--<code>&lt;blui-drawer-header&gt;</code>, 
-                        <code>&lt;blui-drawer-subheader&gt;</code>, 
-                        <code>&lt;blui-drawer-body&gt;</code>,
-                        <code>&lt;blui-drawer-nav-group&gt;</code>,
-                        <code>&lt;blui-drawer-nav-item&gt;</code>,
-                        <code>&lt;blui-drawer-footer&gt;</code> -->
                     </div>
                     <div class="example-demo-wrapper">
                         <app-basic-drawer-demo></app-basic-drawer-demo>
@@ -115,7 +110,13 @@ import { FROM_LIST } from './examples/from-list.component';
                     </div>
                 </div>
             </div>
-            <div playground></div>
+
+            <app-drawer-playground
+                playground
+                [inputs]="allKnobs"
+                (codeChange)="generatedCode = $event"
+            ></app-drawer-playground>
+            <app-example-code code [snippet]="generatedCode" [copyButtonOnHover]="true"></app-example-code>
         </app-component-doc-scaffold>
     `,
     styleUrls: ['./drawer-doc.component.scss'],
@@ -125,8 +126,57 @@ export class DrawerDocComponent {
     BASIC = BASIC;
     ANATOMY = ANATOMY;
     FROM_LIST = FROM_LIST;
-
     routes = DRAWER_NAV_ITEMS;
+    generatedCode: string;
+
+    /* Default playground knobs */
+    requiredKnobs: Partial<DrawerPlaygroundKnobs> = {
+        open: {
+            value: true,
+            type: 'boolean',
+            hint: 'State for the drawer',
+        },
+    };
+    optionalKnobs: Partial<DrawerPlaygroundKnobs> = {
+        disableActiveItemParentStyles: {
+            value: false,
+            componentDefault: false,
+            type: 'boolean',
+            hint: 'NavItems will not have a bold title when a child NavItem is selected',
+        },
+        openOnHover: {
+            value: true,
+            componentDefault: true,
+            type: 'boolean',
+            hint: 'Automatically open the drawer on hover when closed (persistent variant only)',
+        },
+        openOnHoverDelay: {
+            value: 500,
+            componentDefault: 500,
+            type: 'number',
+            hint: 'Delay in milliseconds before a hover event opens the drawer (persistent variant only)',
+            range: { min: 100, max: 1000, tickInterval: 1, step: 100 },
+        },
+        sideBorder: {
+            value: false,
+            componentDefault: false,
+            type: 'boolean',
+            hint: 'Toggle a side border instead of shadow',
+        },
+    };
+    allKnobs = Object.assign({}, this.requiredKnobs, this.optionalKnobs);
+    knobGroups = [
+        {
+            title: 'Required Properties',
+            knobs: this.requiredKnobs,
+            defaultExpanded: true,
+        },
+        {
+            title: 'Optional Properties',
+            knobs: this.optionalKnobs,
+            defaultExpanded: true,
+        },
+    ];
 
     constructor(
         private readonly _splitService: MarkdownSplitService,

--- a/src/docs/pages/component-docs/components/drawer/drawer/drawer-doc.module.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer/drawer-doc.module.ts
@@ -6,9 +6,10 @@ import { BasicExampleComponent } from './examples/basic.component';
 import { AnatomyComponent } from './examples/anatomy.component';
 import { RouterModule } from '@angular/router';
 import { FromListComponent } from './examples/from-list.component';
+import { PlaygroundComponent } from './examples/playground.component';
 
 @NgModule({
-    declarations: [DrawerDocComponent, BasicExampleComponent, AnatomyComponent, FromListComponent],
+    declarations: [DrawerDocComponent, BasicExampleComponent, AnatomyComponent, FromListComponent, PlaygroundComponent],
     imports: [DrawerModule, SpacerModule, SharedCompDocsModule, RouterModule],
     exports: [DrawerDocComponent],
 })

--- a/src/docs/pages/component-docs/components/drawer/drawer/examples/playground.component.ts
+++ b/src/docs/pages/component-docs/components/drawer/drawer/examples/playground.component.ts
@@ -1,0 +1,194 @@
+import { Component, EventEmitter, Input, OnDestroy, Output } from '@angular/core';
+import { PlaygroundService } from '../../../../../../services/playground/playground.service';
+import { Subscription } from 'rxjs';
+import { Knob } from '../../../../shared/scaffold/scaffold.component';
+import { DrawerNavItem } from '@brightlayer-ui/angular-components';
+import * as Colors from '@brightlayer-ui/colors';
+
+export type DrawerPlaygroundKnobs = {
+    openOnHover: Knob;
+    disableActiveItemParentStyles: Knob;
+    open: Knob;
+    openOnHoverDelay: Knob;
+    sideBorder: Knob;
+};
+
+type Group = {
+    items: DrawerNavItem[];
+};
+
+@Component({
+    selector: 'app-drawer-playground',
+    template: ` <blui-drawer
+        class="app-drawer-playground-drawer"
+        *ngIf="inputs"
+        [open]="inputs.open.value"
+        [disableActiveItemParentStyles]="inputs.disableActiveItemParentStyles.value"
+        [openOnHoverDelay]="inputs.openOnHoverDelay.value"
+        [openOnHover]="inputs.openOnHover.value"
+        [sideBorder]="inputs.sideBorder.value"
+    >
+        <blui-drawer-header title="Brightlayer UI" subtitle="Drawer Component">
+            <button mat-icon-button blui-icon>
+                <mat-icon>menu</mat-icon>
+            </button>
+        </blui-drawer-header>
+        <blui-drawer-body>
+            <ng-container *ngFor="let navGroup of [group1]; let first = first">
+                <blui-drawer-nav-group>
+                    <blui-drawer-nav-item
+                        *ngFor="let navItem of navGroup.items"
+                        [title]="navItem.title"
+                        [selected]="selectedItem === navItem.title"
+                        (select)="setActive(navItem)"
+                    >
+                        <mat-icon blui-icon>{{ navItem.icon }}</mat-icon>
+                        <blui-drawer-nav-item
+                            *ngFor="let nestedItem of navItem.items"
+                            [title]="nestedItem.title"
+                            [selected]="selectedItem === nestedItem.title"
+                            (select)="setActive(nestedItem)"
+                        >
+                        </blui-drawer-nav-item>
+                    </blui-drawer-nav-item>
+                </blui-drawer-nav-group>
+            </ng-container>
+        </blui-drawer-body>
+        <blui-drawer-footer [hideContentOnCollapse]="true">
+            <div style="padding: 16px">
+                <div style="display: flex; justify-content: space-between; align-items: center">
+                    <img src="assets/eaton-condensed.png" width="100" style="margin-left: -8px" />
+                    <div>
+                        <div class="mat-caption">Copyright © Eaton</div>
+                        <div class="mat-caption">All Rights Reserved</div>
+                    </div>
+                </div>
+            </div>
+        </blui-drawer-footer>
+    </blui-drawer>`,
+    styles: [
+        `
+            :host {
+                height: 100%;
+            }
+            ::ng-deep .app-drawer-playground-drawer .blui-drawer-content blui-drawer-body {
+                overflow: auto !important;
+            }
+        `,
+    ],
+})
+export class PlaygroundComponent implements OnDestroy {
+    @Input() inputs: DrawerPlaygroundKnobs;
+    @Output() codeChange = new EventEmitter<string>();
+
+    open = true;
+    Colors = Colors;
+    knobListener: Subscription;
+    selectedItem: string;
+
+    group1: Group = {
+        items: [
+            {
+                title: 'Overview',
+                subtitle: 'Learn more about us',
+                statusColor: Colors.green[500],
+                icon: 'dashboard',
+                items: [
+                    {
+                        title: 'Monthly Report',
+                    },
+                    {
+                        title: 'Annual Report',
+                    },
+                ],
+            },
+            {
+                title: 'Timeline',
+                icon: 'toc',
+            },
+            {
+                title: 'Devices',
+                subtitle: '4 new warnings',
+                statusColor: Colors.yellow[500],
+                icon: 'devices',
+            },
+            {
+                title: 'Schedule',
+                icon: 'airport_shuttle',
+            },
+        ],
+    };
+
+    constructor(private readonly _playgroundService: PlaygroundService) {
+        this.knobListener = this._playgroundService.knobChange.subscribe((updatedKnobs: DrawerPlaygroundKnobs) => {
+            this.inputs = updatedKnobs;
+            this.codeChange.emit(this._createGeneratedCode());
+        });
+    }
+
+    ngAfterViewInit(): void {
+        setTimeout(() => {
+            this.codeChange.emit(this._createGeneratedCode());
+        });
+    }
+
+    ngOnDestroy(): void {
+        if (this.knobListener) {
+            this.knobListener.unsubscribe();
+        }
+    }
+    setActive(navItem: DrawerNavItem): void {
+        this.selectedItem = navItem.title;
+    }
+
+    private _createGeneratedCode(): string {
+        const code = `
+<blui-drawer
+    ${this._playgroundService.addOptionalProp(this.inputs, 'disableActiveItemParentStyles')}
+    [open]="${this.inputs.open.value}"
+    ${this._playgroundService.addOptionalProp(this.inputs, 'openOnHover')}
+    ${this._playgroundService.addOptionalProp(this.inputs, 'openOnHoverDelay')}
+    ${this._playgroundService.addOptionalProp(this.inputs, 'sideBorder')}
+>
+    <blui-drawer-header title="Brightlayer UI" subtitle="Drawer Component">
+        <button mat-icon-button blui-icon>
+            <mat-icon>menu</mat-icon>
+        </button>
+    </blui-drawer-header>
+    <blui-drawer-body>
+        <ng-container *ngFor="let navGroup of [group1]; let first = first">
+            <blui-drawer-nav-group>
+                <blui-drawer-nav-item
+                    *ngFor="let navItem of navGroup.items"
+                    [title]="navItem.title"
+                    [selected]="selectedItem === navItem.title"
+                    (select)="setActive(navItem)"
+                >
+                    <mat-icon blui-icon>{{ navItem.icon }}</mat-icon>
+                    <blui-drawer-nav-item
+                        *ngFor="let nestedItem of navItem.items"
+                        [title]="nestedItem.title"
+                        [selected]="selectedItem === nestedItem.title"
+                        (select)="setActive(nestedItem)"
+                    >
+                    </blui-drawer-nav-item>
+                </blui-drawer-nav-item>
+            </blui-drawer-nav-group>
+        </ng-container>
+    </blui-drawer-body>
+    <blui-drawer-footer [hideContentOnCollapse]="true">
+        <div style="padding: 16px">
+            <div style="display: flex; justify-content: space-between; align-items: center">
+                <img src="assets/eaton-condensed.png" width="100" style="margin-left: -8px" />
+                <div>
+                    <div class="mat-caption">Copyright © Eaton</div>
+                    <div class="mat-caption">All Rights Reserved</div>
+                </div>
+            </div>
+        </div>
+    </blui-drawer-footer>
+</blui-drawer>`;
+
+        return this._playgroundService.removeEmptyLines(code);
+    }
+}

--- a/src/docs/pages/component-docs/shared/example-code/example-code.component.scss
+++ b/src/docs/pages/component-docs/shared/example-code/example-code.component.scss
@@ -1,7 +1,7 @@
 .app-example-code {
     display: flex;
     height: 100%;
-    * {
+    code, pre {
         font-family: monospace !important;
     }
     > code {

--- a/src/docs/pages/component-docs/shared/example-code/example-code.component.scss
+++ b/src/docs/pages/component-docs/shared/example-code/example-code.component.scss
@@ -1,7 +1,8 @@
 .app-example-code {
     display: flex;
     height: 100%;
-    code, pre {
+    code,
+    pre {
         font-family: monospace !important;
     }
     > code {

--- a/src/docs/pages/component-docs/shared/example-code/example-code.component.ts
+++ b/src/docs/pages/component-docs/shared/example-code/example-code.component.ts
@@ -6,9 +6,12 @@ import { Component, Input, ViewEncapsulation } from '@angular/core';
         class: 'app-example-code',
     },
     template: `
-        <pre style="display: flex" [attr.data-line]="dataLine" 
-             (mouseenter)="isHoverSnippet=true"
-             (mouseleave)="isHoverSnippet=false">
+        <pre
+            style="display: flex"
+            [attr.data-line]="dataLine"
+            (mouseenter)="isHoverSnippet = true"
+            (mouseleave)="isHoverSnippet = false"
+        >
             <code [innerHTML]="snippet | language: 'html' | markdown"></code>
             <app-copy-code-button [code]="snippet" *ngIf="copyButtonOnHover && isHoverSnippet"
                   style="position: absolute; bottom: 16px; right: 420px;"></app-copy-code-button>

--- a/src/docs/pages/component-docs/shared/example-code/example-code.component.ts
+++ b/src/docs/pages/component-docs/shared/example-code/example-code.component.ts
@@ -6,8 +6,13 @@ import { Component, Input, ViewEncapsulation } from '@angular/core';
         class: 'app-example-code',
     },
     template: `
-        <pre style="display: flex" [attr.data-line]="dataLine">
+        <pre style="display: flex" [attr.data-line]="dataLine" 
+             (mouseenter)="isHoverSnippet=true"
+             (mouseleave)="isHoverSnippet=false">
             <code [innerHTML]="snippet | language: 'html' | markdown"></code>
+            <app-copy-code-button [code]="snippet" 
+                  style="position: absolute; bottom: 16px; right: 420px;"></app-copy-code-button>
+            
         </pre>
     `,
     encapsulation: ViewEncapsulation.None,
@@ -16,6 +21,9 @@ import { Component, Input, ViewEncapsulation } from '@angular/core';
 export class ExampleCodeComponent {
     @Input() snippet: string;
     @Input() dataLine: string;
+    @Input() copyButtonOnHover = false;
+
+    isHoverSnippet: boolean;
 
     ngAfterViewInit(): void {
         window.dispatchEvent(new Event('resize'));

--- a/src/docs/pages/component-docs/shared/example-code/example-code.component.ts
+++ b/src/docs/pages/component-docs/shared/example-code/example-code.component.ts
@@ -10,7 +10,7 @@ import { Component, Input, ViewEncapsulation } from '@angular/core';
              (mouseenter)="isHoverSnippet=true"
              (mouseleave)="isHoverSnippet=false">
             <code [innerHTML]="snippet | language: 'html' | markdown"></code>
-            <app-copy-code-button [code]="snippet" 
+            <app-copy-code-button [code]="snippet" *ngIf="copyButtonOnHover && isHoverSnippet"
                   style="position: absolute; bottom: 16px; right: 420px;"></app-copy-code-button>
             
         </pre>

--- a/src/docs/pages/component-docs/shared/knobs/knob-boolean.component.ts
+++ b/src/docs/pages/component-docs/shared/knobs/knob-boolean.component.ts
@@ -4,9 +4,9 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
     selector: 'app-boolean-knob',
     template: `
         <div style="margin-bottom: 1rem; margin-left: -1rem">
-            <mat-checkbox style="margin-left: 1rem" [(ngModel)]="value" (ngModelChange)="valueChange.emit(value)">{{
-                label
-            }}</mat-checkbox>
+            <mat-checkbox style="margin-left: 1rem" [(ngModel)]="value" (ngModelChange)="valueChange.emit(value)"
+                >{{ label }}<span class="type">: boolean</span>
+            </mat-checkbox>
             <div class="knob-boolean-hint mat-caption" style="padding-left: 2.5rem">{{ hint }}</div>
         </div>
     `,

--- a/src/docs/pages/component-docs/shared/knobs/knob-boolean.component.ts
+++ b/src/docs/pages/component-docs/shared/knobs/knob-boolean.component.ts
@@ -3,7 +3,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 @Component({
     selector: 'app-boolean-knob',
     template: `
-        <div style="margin-bottom: 1rem">
+        <div style="margin-bottom: 1rem; margin-left: -1rem">
             <mat-checkbox style="margin-left: 1rem" [(ngModel)]="value" (ngModelChange)="valueChange.emit(value)">{{
                 label
             }}</mat-checkbox>

--- a/src/docs/pages/component-docs/shared/knobs/knob-color.component.ts
+++ b/src/docs/pages/component-docs/shared/knobs/knob-color.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { FormControl } from '@angular/forms';
 
 @Component({
     selector: 'app-color-knob',
@@ -7,17 +8,13 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
             <mat-form-field appearance="fill" style="margin-bottom: 1rem" blui-input>
                 <mat-label>{{ label }}: color</mat-label>
                 <mat-hint>{{ hint }}</mat-hint>
-                <input
-                    matInput
-                    [(ngModel)]="value"
-                    (ngModelChange)="valueChange.emit($event)"
-                    [ngModelOptions]="{ standalone: true }"
-                />
+                <mat-error *ngIf="colorInput.errors?.['colorInvalid']"> Color value not recognized </mat-error>
+                <input matInput [formControl]="colorInput" [(ngModel)]="value" (ngModelChange)="updateValue($event)" />
                 <button
                     mat-icon-button
                     matSuffix
                     style="cursor: pointer; padding-bottom: 4px; margin-right: 0;"
-                    [style.marginTop.px]="isValidColor() ? -4 : 0"
+                    [style.marginTop.px]="hasValidColor ? -4 : 0"
                     [style.borderBottomColor]="value"
                     [cpPosition]="'bottom'"
                     [cpPositionOffset]="'-750px'"
@@ -25,12 +22,12 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
                     (colorPickerChange)="valueChange.emit($event)"
                     [(colorPicker)]="value"
                 >
-                    <mat-icon>{{ isValidColor() ? 'colorize' : 'question_mark' }}</mat-icon>
+                    <mat-icon>{{ hasValidColor ? 'colorize' : 'question_mark' }}</mat-icon>
                 </button>
             </mat-form-field>
             <div
                 class="divider-border"
-                *ngIf="isValidColor()"
+                *ngIf="hasValidColor"
                 style="position: absolute; z-index: 3; width: 40px; height: 8px; top: 40px; right: 12px; box-sizing: border-box"
                 [style.backgroundColor]="value"
             ></div>
@@ -43,9 +40,24 @@ export class KnobColorComponent {
     @Input() label;
     @Output() valueChange = new EventEmitter<string>();
 
-    isValidColor(): boolean {
+    hasValidColor: boolean;
+    colorInput = new FormControl('', []);
+
+    updateValue(e: string): void {
+        this.value = e;
+        this.valueChange.emit(e);
+        this.hasValidColor = this._checkValidColor();
+        if (this.hasValidColor) {
+            this.colorInput.setErrors(null);
+        } else {
+            this.colorInput.setErrors({ colorInvalid: true });
+        }
+    }
+
+    private _checkValidColor(): boolean {
         const s = new Option().style;
         s.color = this.value;
-        return s.color !== '';
+        const valid = s.color !== '';
+        return valid;
     }
 }

--- a/src/docs/pages/component-docs/shared/knobs/knob-color.component.ts
+++ b/src/docs/pages/component-docs/shared/knobs/knob-color.component.ts
@@ -6,7 +6,7 @@ import { FormControl } from '@angular/forms';
     template: `
         <div style="position: relative">
             <mat-form-field appearance="fill" style="margin-bottom: 1rem" blui-input>
-                <mat-label>{{ label }}: color</mat-label>
+                <mat-label>{{ label }}: string</mat-label>
                 <mat-hint>{{ hint }}</mat-hint>
                 <mat-error *ngIf="colorInput.errors?.['colorInvalid']"> Color value not recognized </mat-error>
                 <input matInput [formControl]="colorInput" [(ngModel)]="value" (ngModelChange)="updateValue($event)" />

--- a/src/docs/pages/component-docs/shared/knobs/knob-color.component.ts
+++ b/src/docs/pages/component-docs/shared/knobs/knob-color.component.ts
@@ -8,27 +8,31 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
                 <mat-label>{{ label }}: color</mat-label>
                 <mat-hint>{{ hint }}</mat-hint>
                 <input
-                        matInput
-                        [(ngModel)]="value"
-                        (ngModelChange)="valueChange.emit($event)"
-                        [ngModelOptions]="{ standalone: true }"
+                    matInput
+                    [(ngModel)]="value"
+                    (ngModelChange)="valueChange.emit($event)"
+                    [ngModelOptions]="{ standalone: true }"
                 />
-                <button mat-icon-button matSuffix  
-                        style="cursor: pointer; padding-bottom: 4px; margin-right: 0;"
-                        [style.marginTop.px]="isValidColor() ? -4 : 0"
-                        [style.borderBottomColor]="value"
-                        [cpPosition]="'bottom'"
-                        [cpPositionOffset]="'-750px'"
-                        [cpPositionRelativeToArrow]="true"
-                        (colorPickerChange)="valueChange.emit($event)"
-                        [(colorPicker)]="value">
-                    <mat-icon>{{ isValidColor() ? 'colorize' : 'question_mark'}}</mat-icon>
+                <button
+                    mat-icon-button
+                    matSuffix
+                    style="cursor: pointer; padding-bottom: 4px; margin-right: 0;"
+                    [style.marginTop.px]="isValidColor() ? -4 : 0"
+                    [style.borderBottomColor]="value"
+                    [cpPosition]="'bottom'"
+                    [cpPositionOffset]="'-750px'"
+                    [cpPositionRelativeToArrow]="true"
+                    (colorPickerChange)="valueChange.emit($event)"
+                    [(colorPicker)]="value"
+                >
+                    <mat-icon>{{ isValidColor() ? 'colorize' : 'question_mark' }}</mat-icon>
                 </button>
             </mat-form-field>
-            <div class="divider-border" 
-                 *ngIf="isValidColor()"
-                 style="position: absolute; z-index: 3; width: 40px; height: 8px; top: 40px; right: 12px; box-sizing: border-box"
-                 [style.backgroundColor]="value"
+            <div
+                class="divider-border"
+                *ngIf="isValidColor()"
+                style="position: absolute; z-index: 3; width: 40px; height: 8px; top: 40px; right: 12px; box-sizing: border-box"
+                [style.backgroundColor]="value"
             ></div>
         </div>
     `,

--- a/src/docs/pages/component-docs/shared/knobs/knob-color.component.ts
+++ b/src/docs/pages/component-docs/shared/knobs/knob-color.component.ts
@@ -55,6 +55,10 @@ export class KnobColorComponent {
     }
 
     private _checkValidColor(): boolean {
+        if (!this.value) {
+            return true;
+        }
+
         const s = new Option().style;
         s.color = this.value;
         const valid = s.color !== '';

--- a/src/docs/pages/component-docs/shared/knobs/knob-color.component.ts
+++ b/src/docs/pages/component-docs/shared/knobs/knob-color.component.ts
@@ -3,27 +3,34 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 @Component({
     selector: 'app-color-knob',
     template: `
-        <mat-form-field appearance="fill" style="margin-bottom: 1rem">
-            <mat-label>{{ label }}: color</mat-label>
-            <mat-hint>{{ hint }}</mat-hint>
-            <input
-                matInput
-                [(ngModel)]="value"
-                (ngModelChange)="valueChange.emit($event)"
-                [ngModelOptions]="{ standalone: true }"
-            />
-            <mat-icon
-                matSuffix
-                style="cursor: pointer"
-                [style.color]="value"
-                [cpPosition]="'bottom'"
-                [cpPositionOffset]="'-750px'"
-                [cpPositionRelativeToArrow]="true"
-                (colorPickerChange)="valueChange.emit($event)"
-                [(colorPicker)]="value"
-                >palette</mat-icon
-            >
-        </mat-form-field>
+        <div style="position: relative">
+            <mat-form-field appearance="fill" style="margin-bottom: 1rem" blui-input>
+                <mat-label>{{ label }}: color</mat-label>
+                <mat-hint>{{ hint }}</mat-hint>
+                <input
+                        matInput
+                        [(ngModel)]="value"
+                        (ngModelChange)="valueChange.emit($event)"
+                        [ngModelOptions]="{ standalone: true }"
+                />
+                <button mat-icon-button matSuffix  
+                        style="cursor: pointer; padding-bottom: 4px; margin-right: 0;"
+                        [style.marginTop.px]="isValidColor() ? -4 : 0"
+                        [style.borderBottomColor]="value"
+                        [cpPosition]="'bottom'"
+                        [cpPositionOffset]="'-750px'"
+                        [cpPositionRelativeToArrow]="true"
+                        (colorPickerChange)="valueChange.emit($event)"
+                        [(colorPicker)]="value">
+                    <mat-icon>{{ isValidColor() ? 'colorize' : 'question_mark'}}</mat-icon>
+                </button>
+            </mat-form-field>
+            <div class="divider-border" 
+                 *ngIf="isValidColor()"
+                 style="position: absolute; z-index: 3; width: 40px; height: 8px; top: 40px; right: 12px; box-sizing: border-box"
+                 [style.backgroundColor]="value"
+            ></div>
+        </div>
     `,
 })
 export class KnobColorComponent {
@@ -31,4 +38,10 @@ export class KnobColorComponent {
     @Input() hint;
     @Input() label;
     @Output() valueChange = new EventEmitter<string>();
+
+    isValidColor(): boolean {
+        const s = new Option().style;
+        s.color = this.value;
+        return s.color !== '';
+    }
 }

--- a/src/docs/pages/component-docs/shared/knobs/knob-number.component.ts
+++ b/src/docs/pages/component-docs/shared/knobs/knob-number.component.ts
@@ -4,28 +4,22 @@ import { MatSliderChange } from '@angular/material/slider';
 @Component({
     selector: 'app-number-knob',
     template: `
-        <div style="position: relative">
-            <div
-                style="opacity: 0; z-index: 2; width: 310px; height: 60px; position: absolute"
-                (click)="isOpen = true"
-            ></div>
-            <mat-form-field appearance="fill" style="margin-bottom: 1rem" #input>
-                <mat-label>{{ label }}: string</mat-label>
-                <mat-hint>{{ hint }}</mat-hint>
-                <input
-                    type="number"
-                    [max]="max"
-                    [min]="min"
-                    cdkOverlayOrigin
-                    #trigger="cdkOverlayOrigin"
-                    [class.hiddenArrows]="isOpen"
-                    matInput
-                    [(ngModel)]="value"
-                    (ngModelChange)="valueChange.emit($event)"
-                    [ngModelOptions]="{ standalone: true }"
-                />
-            </mat-form-field>
-        </div>
+        <mat-form-field appearance="fill" style="margin-bottom: 1rem" #input (click)="isOpen = true">
+            <mat-label>{{ label }}: string</mat-label>
+            <mat-hint>{{ hint }}</mat-hint>
+            <input
+                type="number"
+                [max]="max"
+                [min]="min"
+                cdkOverlayOrigin
+                #trigger="cdkOverlayOrigin"
+                [class.hiddenArrows]="true"
+                matInput
+                [(ngModel)]="value"
+                (ngModelChange)="valueChange.emit($event)"
+                [ngModelOptions]="{ standalone: true }"
+            />
+        </mat-form-field>
 
         <ng-template
             cdkConnectedOverlay

--- a/src/docs/pages/component-docs/shared/knobs/knob-number.component.ts
+++ b/src/docs/pages/component-docs/shared/knobs/knob-number.component.ts
@@ -1,0 +1,73 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { MatSliderChange } from '@angular/material/slider';
+
+@Component({
+    selector: 'app-number-knob',
+    template: `
+        <mat-form-field
+            appearance="fill"
+            style="margin-bottom: 1rem"
+            (mouseenter)="isHoverInput = true"
+            (mouseleave)="isHoverInput = false"
+        >
+            <mat-label>{{ label }}: string</mat-label>
+            <mat-hint>{{ hint }}</mat-hint>
+            <input
+                type="number"
+                [max]="max"
+                [min]="min"
+                cdkOverlayOrigin
+                #trigger="cdkOverlayOrigin"
+                matInput
+                [(ngModel)]="value"
+                (ngModelChange)="valueChange.emit($event)"
+                [ngModelOptions]="{ standalone: true }"
+                (click)="isOpen = true"
+            />
+        </mat-form-field>
+
+        <ng-template
+            cdkConnectedOverlay
+            [cdkConnectedOverlayOrigin]="trigger"
+            [cdkConnectedOverlayOpen]="isOpen"
+            cdkConnectedOverlayBackdropClass="number-knob-backdrop"
+            [cdkConnectedOverlayHasBackdrop]="true"
+            (backdropClick)="clickedBackdrop()"
+        >
+            <div style="padding-top: 12px">
+                <div style="margin-left: -16px; padding: 0 8px" class="slider-knob-overlay divider-border">
+                    <mat-slider
+                        style="width: 334px"
+                        [(ngModel)]="value"
+                        [min]="min"
+                        [max]="max"
+                        (input)="updateValue($event)"
+                    ></mat-slider>
+                </div>
+            </div>
+        </ng-template>
+    `,
+})
+export class KnobNumberComponent {
+    @Input() max: number;
+    @Input() min: number;
+    @Input() value;
+    @Input() hint;
+    @Input() label;
+    @Output() valueChange = new EventEmitter<number>();
+
+    isOpen: boolean;
+    isHoverInput: boolean;
+
+    updateValue(e: MatSliderChange): void {
+        this.value = e.value;
+    }
+
+    clickedBackdrop(): void {
+        console.log('hi');
+        if (this.isHoverInput) {
+            return;
+        }
+        this.isOpen = false;
+    }
+}

--- a/src/docs/pages/component-docs/shared/knobs/knob-number.component.ts
+++ b/src/docs/pages/component-docs/shared/knobs/knob-number.component.ts
@@ -32,10 +32,12 @@ import { MatSliderChange } from '@angular/material/slider';
             <div style="padding-top: 12px">
                 <div style="margin-left: -16px; padding: 0 8px" class="slider-knob-overlay divider-border">
                     <mat-slider
-                        style="width: 334px"
+                        style="width: 332px"
                         [(ngModel)]="value"
                         [min]="min"
                         [max]="max"
+                        [tickInterval]="tickInterval"
+                        [step]="step"
                         (input)="updateValue($event)"
                     ></mat-slider>
                 </div>
@@ -61,6 +63,8 @@ import { MatSliderChange } from '@angular/material/slider';
 export class KnobNumberComponent {
     @Input() max: number;
     @Input() min: number;
+    @Input() tickInterval: number;
+    @Input() step: number;
     @Input() value;
     @Input() hint;
     @Input() label;
@@ -70,6 +74,7 @@ export class KnobNumberComponent {
 
     updateValue(e: MatSliderChange): void {
         this.value = e.value;
+        this.valueChange.emit(e.value);
     }
 
     clickedBackdrop(): void {

--- a/src/docs/pages/component-docs/shared/knobs/knob-number.component.ts
+++ b/src/docs/pages/component-docs/shared/knobs/knob-number.component.ts
@@ -4,8 +4,8 @@ import { MatSliderChange } from '@angular/material/slider';
 @Component({
     selector: 'app-number-knob',
     template: `
-        <mat-form-field appearance="fill" style="margin-bottom: 1rem" #input (click)="isOpen = true">
-            <mat-label>{{ label }}: string</mat-label>
+        <mat-form-field appearance="fill" style="margin-bottom: 1rem" #input (click)="isOpen = true" [class]="label">
+            <mat-label>{{ label }}: number</mat-label>
             <mat-hint>{{ hint }}</mat-hint>
             <input
                 type="number"

--- a/src/docs/pages/component-docs/shared/knobs/knob-number.component.ts
+++ b/src/docs/pages/component-docs/shared/knobs/knob-number.component.ts
@@ -4,27 +4,28 @@ import { MatSliderChange } from '@angular/material/slider';
 @Component({
     selector: 'app-number-knob',
     template: `
-        <mat-form-field
-            appearance="fill"
-            style="margin-bottom: 1rem"
-            (mouseenter)="isHoverInput = true"
-            (mouseleave)="isHoverInput = false"
-        >
-            <mat-label>{{ label }}: string</mat-label>
-            <mat-hint>{{ hint }}</mat-hint>
-            <input
-                type="number"
-                [max]="max"
-                [min]="min"
-                cdkOverlayOrigin
-                #trigger="cdkOverlayOrigin"
-                matInput
-                [(ngModel)]="value"
-                (ngModelChange)="valueChange.emit($event)"
-                [ngModelOptions]="{ standalone: true }"
+        <div style="position: relative">
+            <div
+                style="opacity: 0; z-index: 2; width: 310px; height: 60px; position: absolute"
                 (click)="isOpen = true"
-            />
-        </mat-form-field>
+            ></div>
+            <mat-form-field appearance="fill" style="margin-bottom: 1rem" #input>
+                <mat-label>{{ label }}: string</mat-label>
+                <mat-hint>{{ hint }}</mat-hint>
+                <input
+                    type="number"
+                    [max]="max"
+                    [min]="min"
+                    cdkOverlayOrigin
+                    #trigger="cdkOverlayOrigin"
+                    [class.hiddenArrows]="isOpen"
+                    matInput
+                    [(ngModel)]="value"
+                    (ngModelChange)="valueChange.emit($event)"
+                    [ngModelOptions]="{ standalone: true }"
+                />
+            </mat-form-field>
+        </div>
 
         <ng-template
             cdkConnectedOverlay
@@ -47,6 +48,21 @@ import { MatSliderChange } from '@angular/material/slider';
             </div>
         </ng-template>
     `,
+    styles: [
+        `
+            /* Chrome, Safari, Edge, Opera */
+            .hiddenArrows::-webkit-outer-spin-button,
+            .hiddenArrows::-webkit-inner-spin-button {
+                -webkit-appearance: none;
+                margin: 0;
+            }
+
+            /* Firefox */
+            .hiddenArrows[type='number'] {
+                -moz-appearance: textfield;
+            }
+        `,
+    ],
 })
 export class KnobNumberComponent {
     @Input() max: number;
@@ -57,17 +73,12 @@ export class KnobNumberComponent {
     @Output() valueChange = new EventEmitter<number>();
 
     isOpen: boolean;
-    isHoverInput: boolean;
 
     updateValue(e: MatSliderChange): void {
         this.value = e.value;
     }
 
     clickedBackdrop(): void {
-        console.log('hi');
-        if (this.isHoverInput) {
-            return;
-        }
         this.isOpen = false;
     }
 }

--- a/src/docs/pages/component-docs/shared/scaffold/scaffold.component.scss
+++ b/src/docs/pages/component-docs/shared/scaffold/scaffold.component.scss
@@ -151,9 +151,18 @@
         padding: 16px;
 
         input,
+        .mat-checkbox-label,
         .mat-select-value-text {
             font-family: monospace;
         }
+        .non-prop {
+            input,
+            .mat-checkbox-label,
+            .mat-select-value-text {
+                font-family: inherit;
+            }
+        }
+
         .mat-expansion-panel .mat-expansion-panel-header.mat-expanded {
             border-bottom: 0 !important;
         }

--- a/src/docs/pages/component-docs/shared/scaffold/scaffold.component.scss
+++ b/src/docs/pages/component-docs/shared/scaffold/scaffold.component.scss
@@ -134,6 +134,7 @@
         height: 100%;
         margin-right: $knobsWidth;
         .playground-live-example-wrapper {
+            padding: 1rem;
             height: 50%;
             display: flex;
             justify-content: center;

--- a/src/docs/pages/component-docs/shared/scaffold/scaffold.component.scss
+++ b/src/docs/pages/component-docs/shared/scaffold/scaffold.component.scss
@@ -168,6 +168,9 @@
             .mat-select-value-text {
                 font-family: inherit;
             }
+            app-boolean-knob .type {
+                display: none;
+            }
         }
 
         .mat-expansion-panel .mat-expansion-panel-header.mat-expanded {

--- a/src/docs/pages/component-docs/shared/scaffold/scaffold.component.scss
+++ b/src/docs/pages/component-docs/shared/scaffold/scaffold.component.scss
@@ -149,6 +149,15 @@
         position: fixed;
         right: 0;
         padding: 16px;
+
+
+        .mat-expansion-panel .mat-expansion-panel-header.mat-expanded {
+            border-bottom: 0!important;
+        }
+        .mat-expansion-panel-body, .mat-expansion-panel-header {
+            padding: 0 8px;
+        }
+
         mat-form-field {
             width: 100%;
         }

--- a/src/docs/pages/component-docs/shared/scaffold/scaffold.component.scss
+++ b/src/docs/pages/component-docs/shared/scaffold/scaffold.component.scss
@@ -151,9 +151,10 @@
         padding: 16px;
 
         .mat-expansion-panel .mat-expansion-panel-header.mat-expanded {
-            border-bottom: 0!important;
+            border-bottom: 0 !important;
         }
-        .mat-expansion-panel-body, .mat-expansion-panel-header {
+        .mat-expansion-panel-body,
+        .mat-expansion-panel-header {
             padding: 0 8px;
         }
 

--- a/src/docs/pages/component-docs/shared/scaffold/scaffold.component.scss
+++ b/src/docs/pages/component-docs/shared/scaffold/scaffold.component.scss
@@ -150,7 +150,6 @@
         right: 0;
         padding: 16px;
 
-
         .mat-expansion-panel .mat-expansion-panel-header.mat-expanded {
             border-bottom: 0!important;
         }

--- a/src/docs/pages/component-docs/shared/scaffold/scaffold.component.scss
+++ b/src/docs/pages/component-docs/shared/scaffold/scaffold.component.scss
@@ -39,7 +39,13 @@
 
         /* Examples Section */
         .examples-tab-content-wrapper {
-            padding: 48px 32px 32px 32px;
+            padding: 48px 0px 32px 0px;
+
+            @media only screen and (max-width: 1590px) {
+                margin-left: 32px;
+                margin-right: 32px;
+            }
+
             > div {
                 display: flex;
                 flex-direction: column;
@@ -174,6 +180,11 @@
 
         mat-form-field {
             width: 100%;
+        }
+
+        /* Manual Knob Adjustments */
+        .openOnHoverDelay {
+            margin-bottom: 2rem !important;
         }
     }
 }

--- a/src/docs/pages/component-docs/shared/scaffold/scaffold.component.scss
+++ b/src/docs/pages/component-docs/shared/scaffold/scaffold.component.scss
@@ -150,6 +150,10 @@
         right: 0;
         padding: 16px;
 
+        input,
+        .mat-select-value-text {
+            font-family: monospace;
+        }
         .mat-expansion-panel .mat-expansion-panel-header.mat-expanded {
             border-bottom: 0 !important;
         }

--- a/src/docs/pages/component-docs/shared/scaffold/scaffold.component.ts
+++ b/src/docs/pages/component-docs/shared/scaffold/scaffold.component.ts
@@ -65,35 +65,35 @@ export type Knob = {
                                     {{ group.title }}
                                 </mat-panel-title>
                             </mat-expansion-panel-header>
-                            <ng-container *ngFor="let key of getKeys()">
+                            <ng-container *ngFor="let key of getKeys(group.knobs)">
                                 <app-select-knob
-                                    *ngIf="knobs[key].type === 'select'"
-                                    [label]="knobs[key].label || key"
-                                    [options]="knobs[key].options"
-                                    [(value)]="knobs[key].value"
-                                    [hint]="knobs[key].hint"
-                                    (valueChange)="emitKnobChange(knobs)"
+                                    *ngIf="group.knobs[key].type === 'select'"
+                                    [label]="group.knobs[key].label || key"
+                                    [options]="group.knobs[key].options"
+                                    [(value)]="group.knobs[key].value"
+                                    [hint]="group.knobs[key].hint"
+                                    (valueChange)="emitKnobChange()"
                                 ></app-select-knob>
                                 <app-color-knob
-                                    *ngIf="knobs[key].type === 'color'"
-                                    [label]="knobs[key].label || key"
-                                    [(value)]="knobs[key].value"
-                                    [hint]="knobs[key].hint"
-                                    (valueChange)="emitKnobChange(knobs)"
+                                    *ngIf="group.knobs[key].type === 'color'"
+                                    [label]="group.knobs[key].label || key"
+                                    [(value)]="group.knobs[key].value"
+                                    [hint]="group.knobs[key].hint"
+                                    (valueChange)="emitKnobChange()"
                                 ></app-color-knob>
                                 <app-text-knob
-                                    *ngIf="knobs[key].type === 'string'"
-                                    [label]="knobs[key].label || key"
-                                    [(value)]="knobs[key].value"
-                                    [hint]="knobs[key].hint"
-                                    (valueChange)="emitKnobChange(knobs)"
+                                    *ngIf="group.knobs[key].type === 'string'"
+                                    [label]="group.knobs[key].label || key"
+                                    [(value)]="group.knobs[key].value"
+                                    [hint]="group.knobs[key].hint"
+                                    (valueChange)="emitKnobChange()"
                                 ></app-text-knob>
                                 <app-boolean-knob
-                                    *ngIf="knobs[key].type === 'boolean'"
-                                    [label]="knobs[key].label || key"
-                                    [(value)]="knobs[key].value"
-                                    [hint]="knobs[key].hint"
-                                    (valueChange)="emitKnobChange(knobs)"
+                                    *ngIf="group.knobs[key].type === 'boolean'"
+                                    [label]="group.knobs[key].label || key"
+                                    [(value)]="group.knobs[key].value"
+                                    [hint]="group.knobs[key].hint"
+                                    (valueChange)="emitKnobChange()"
                                 ></app-boolean-knob>
                             </ng-container>
                         </mat-expansion-panel>
@@ -109,8 +109,7 @@ export class ScaffoldComponent implements OnInit, OnDestroy {
     @Input() useDefaultDocs = true;
     @Input() mdFileName: string;
     @Input() md: string;
-    @Input() knobs: { [key: string]: Knob };
-    @Input() knobGroups: Array<{ title: string; knobs: [key: string]; defaultExpanded: boolean }>;
+    @Input() knobGroups: Array<{ title: string; knobs: { [key: string]: Knob }; defaultExpanded: boolean }>;
 
     currentTabIndex = 0;
 
@@ -124,8 +123,8 @@ export class ScaffoldComponent implements OnInit, OnDestroy {
         private readonly _viewportService: ViewportService
     ) {}
 
-    getKeys(): any {
-        return Object.keys(this.knobs || {});
+    getKeys(knobs): any {
+        return Object.keys(knobs || {});
     }
 
     ngOnInit(): void {
@@ -168,7 +167,9 @@ export class ScaffoldComponent implements OnInit, OnDestroy {
     }
 
     /** Emits an event whenever a knob has been udpated. */
-    emitKnobChange(knobs: { [key: string]: Knob }): void {
+    emitKnobChange(): void {
+        const knobs = {};
+        this.knobGroups.map((group) => Object.assign(knobs, group.knobs));
         this._playgroundService.knobChange.next(knobs);
     }
 

--- a/src/docs/pages/component-docs/shared/scaffold/scaffold.component.ts
+++ b/src/docs/pages/component-docs/shared/scaffold/scaffold.component.ts
@@ -67,33 +67,33 @@ export type Knob = {
                             </mat-expansion-panel-header>
                             <ng-container *ngFor="let key of getKeys()">
                                 <app-select-knob
-                                        *ngIf="knobs[key].type === 'select'"
-                                        [label]="knobs[key].label || key"
-                                        [options]="knobs[key].options"
-                                        [(value)]="knobs[key].value"
-                                        [hint]="knobs[key].hint"
-                                        (valueChange)="emitKnobChange(knobs)"
+                                    *ngIf="knobs[key].type === 'select'"
+                                    [label]="knobs[key].label || key"
+                                    [options]="knobs[key].options"
+                                    [(value)]="knobs[key].value"
+                                    [hint]="knobs[key].hint"
+                                    (valueChange)="emitKnobChange(knobs)"
                                 ></app-select-knob>
                                 <app-color-knob
-                                        *ngIf="knobs[key].type === 'color'"
-                                        [label]="knobs[key].label || key"
-                                        [(value)]="knobs[key].value"
-                                        [hint]="knobs[key].hint"
-                                        (valueChange)="emitKnobChange(knobs)"
+                                    *ngIf="knobs[key].type === 'color'"
+                                    [label]="knobs[key].label || key"
+                                    [(value)]="knobs[key].value"
+                                    [hint]="knobs[key].hint"
+                                    (valueChange)="emitKnobChange(knobs)"
                                 ></app-color-knob>
                                 <app-text-knob
-                                        *ngIf="knobs[key].type === 'string'"
-                                        [label]="knobs[key].label || key"
-                                        [(value)]="knobs[key].value"
-                                        [hint]="knobs[key].hint"
-                                        (valueChange)="emitKnobChange(knobs)"
+                                    *ngIf="knobs[key].type === 'string'"
+                                    [label]="knobs[key].label || key"
+                                    [(value)]="knobs[key].value"
+                                    [hint]="knobs[key].hint"
+                                    (valueChange)="emitKnobChange(knobs)"
                                 ></app-text-knob>
                                 <app-boolean-knob
-                                        *ngIf="knobs[key].type === 'boolean'"
-                                        [label]="knobs[key].label || key"
-                                        [(value)]="knobs[key].value"
-                                        [hint]="knobs[key].hint"
-                                        (valueChange)="emitKnobChange(knobs)"
+                                    *ngIf="knobs[key].type === 'boolean'"
+                                    [label]="knobs[key].label || key"
+                                    [(value)]="knobs[key].value"
+                                    [hint]="knobs[key].hint"
+                                    (valueChange)="emitKnobChange(knobs)"
                                 ></app-boolean-knob>
                             </ng-container>
                         </mat-expansion-panel>
@@ -110,8 +110,7 @@ export class ScaffoldComponent implements OnInit, OnDestroy {
     @Input() mdFileName: string;
     @Input() md: string;
     @Input() knobs: { [key: string]: Knob };
-    @Input() knobGroups: Array<{ title: string, knobs: [key: string], defaultExpanded: boolean; }>;
-
+    @Input() knobGroups: Array<{ title: string; knobs: [key: string]; defaultExpanded: boolean }>;
 
     currentTabIndex = 0;
 

--- a/src/docs/pages/component-docs/shared/scaffold/scaffold.component.ts
+++ b/src/docs/pages/component-docs/shared/scaffold/scaffold.component.ts
@@ -133,7 +133,7 @@ export class ScaffoldComponent implements OnInit, OnDestroy {
         private readonly _viewportService: ViewportService
     ) {}
 
-    getKeys(knobs): any {
+    getKeys(knobs: { [key: string]: Knob }): any {
         return Object.keys(knobs || {});
     }
 

--- a/src/docs/pages/component-docs/shared/scaffold/scaffold.component.ts
+++ b/src/docs/pages/component-docs/shared/scaffold/scaffold.component.ts
@@ -12,7 +12,7 @@ export type Knob = {
     label?: string;
     value: any;
     componentDefault?: string | boolean | number;
-    range?: { min: number; max: number };
+    range?: { min: number; max: number; tickInterval: number; step: number };
     type: 'string' | 'color' | 'select' | 'number' | 'boolean';
     hint: string;
     options?: string[];
@@ -135,6 +135,8 @@ export type Knob = {
                     [(value)]="knob.value"
                     [max]="knob.range.max"
                     [min]="knob.range.min"
+                    [tickInterval]="knob.range.tickInterval"
+                    [step]="knob.range.step"
                     [hint]="knob.hint"
                     (valueChange)="emitKnobChange()"
                 ></app-number-knob>

--- a/src/docs/pages/component-docs/shared/scaffold/scaffold.component.ts
+++ b/src/docs/pages/component-docs/shared/scaffold/scaffold.component.ts
@@ -34,7 +34,7 @@ export type Knob = {
                     (selectedTabChange)="userChangeTab($event)"
                     [(selectedIndex)]="currentTabIndex"
                 >
-                    <mat-tab label="Examples">
+                    <mat-tab label="Examples" *ngIf="hasExamples">
                         <div class="examples-tab-content-wrapper">
                             <ng-content select="[examples]"></ng-content>
                         </div>
@@ -45,7 +45,7 @@ export type Knob = {
                             <ng-content select="[docs]"></ng-content>
                         </div>
                     </mat-tab>
-                    <mat-tab label="Playground"></mat-tab>
+                    <mat-tab label="Playground" *ngIf="hasPlayground"></mat-tab>
                 </mat-tab-group>
             </div>
 
@@ -145,6 +145,8 @@ export type Knob = {
     encapsulation: ViewEncapsulation.None,
 })
 export class ScaffoldComponent implements OnInit, OnDestroy {
+    @Input() hasExamples = true;
+    @Input() hasPlayground = true;
     @Input() useDefaultDocs = true;
     @Input() mdFileName: string;
     @Input() md: string;

--- a/src/docs/pages/component-docs/shared/scaffold/scaffold.component.ts
+++ b/src/docs/pages/component-docs/shared/scaffold/scaffold.component.ts
@@ -60,7 +60,7 @@ export type Knob = {
                 </div>
                 <div class="props-container">
                     <ng-container *ngIf="knobGroups.length > 1">
-                        <mat-accordion *ngFor="let group of knobGroups">
+                        <mat-accordion *ngFor="let group of knobGroups; let last = last">
                             <mat-expansion-panel [expanded]="group.defaultExpanded" class="mat-elevation-z0">
                                 <mat-expansion-panel-header>
                                     <mat-panel-title class="blui-subtitle-1 primary">
@@ -77,6 +77,7 @@ export type Knob = {
                                     </ng-template>
                                 </ng-container>
                             </mat-expansion-panel>
+                            <mat-divider *ngIf="!last" style="margin-left: -16px; margin-right: -16px"></mat-divider>
                         </mat-accordion>
                     </ng-container>
 

--- a/src/docs/pages/component-docs/shared/scaffold/scaffold.component.ts
+++ b/src/docs/pages/component-docs/shared/scaffold/scaffold.component.ts
@@ -51,66 +51,93 @@ export type Knob = {
 
             <div class="playground-container" *ngIf="currentTabIndex === 2">
                 <div style="width: 100%; display: flex; flex-direction: column;">
-                    <div class="playground-live-example-wrapper" style="height: 50%">
+                    <div class="playground-live-example-wrapper" style="height: 70%">
                         <ng-content select="[playground]"></ng-content>
                     </div>
-                    <div style="height: 50%; overflow: auto; box-sizing: border-box">
+                    <div style="height: 30%; overflow: auto; box-sizing: border-box">
                         <ng-content select="[code]"></ng-content>
                     </div>
                 </div>
                 <div class="props-container">
-                    <mat-accordion *ngFor="let group of knobGroups">
-                        <mat-expansion-panel [expanded]="group.defaultExpanded" class="mat-elevation-z0">
-                            <mat-expansion-panel-header>
-                                <mat-panel-title class="blui-subtitle-1">
-                                    {{ group.title }}
-                                </mat-panel-title>
-                            </mat-expansion-panel-header>
-                            <ng-container *ngFor="let key of getKeys(group.knobs)">
-                                <app-select-knob
-                                    *ngIf="group.knobs[key].type === 'select'"
-                                    [label]="group.knobs[key].label || key"
-                                    [options]="group.knobs[key].options"
-                                    [(value)]="group.knobs[key].value"
-                                    [hint]="group.knobs[key].hint"
-                                    (valueChange)="emitKnobChange()"
-                                ></app-select-knob>
-                                <app-color-knob
-                                    *ngIf="group.knobs[key].type === 'color'"
-                                    [label]="group.knobs[key].label || key"
-                                    [(value)]="group.knobs[key].value"
-                                    [hint]="group.knobs[key].hint"
-                                    (valueChange)="emitKnobChange()"
-                                ></app-color-knob>
-                                <app-text-knob
-                                    *ngIf="group.knobs[key].type === 'string'"
-                                    [label]="group.knobs[key].label || key"
-                                    [(value)]="group.knobs[key].value"
-                                    [hint]="group.knobs[key].hint"
-                                    (valueChange)="emitKnobChange()"
-                                ></app-text-knob>
-                                <app-boolean-knob
-                                    *ngIf="group.knobs[key].type === 'boolean'"
-                                    [label]="group.knobs[key].label || key"
-                                    [(value)]="group.knobs[key].value"
-                                    [hint]="group.knobs[key].hint"
-                                    (valueChange)="emitKnobChange()"
-                                ></app-boolean-knob>
-                                <app-number-knob
-                                    *ngIf="group.knobs[key].type === 'number'"
-                                    [label]="group.knobs[key].label || key"
-                                    [(value)]="group.knobs[key].value"
-                                    [max]="group.knobs[key].range.max"
-                                    [min]="group.knobs[key].range.min"
-                                    [hint]="group.knobs[key].hint"
-                                    (valueChange)="emitKnobChange()"
-                                ></app-number-knob>
-                            </ng-container>
-                        </mat-expansion-panel>
-                    </mat-accordion>
+                    <ng-container *ngIf="knobGroups.length > 1">
+                        <mat-accordion *ngFor="let group of knobGroups">
+                            <mat-expansion-panel [expanded]="group.defaultExpanded" class="mat-elevation-z0">
+                                <mat-expansion-panel-header>
+                                    <mat-panel-title class="blui-subtitle-1 primary">
+                                        {{ group.title }}
+                                    </mat-panel-title>
+                                </mat-expansion-panel-header>
+                                <ng-container *ngFor="let key of getKeys(group.knobs)">
+                                    <ng-template
+                                        *ngTemplateOutlet="
+                                            interactiveKnob;
+                                            context: { knob: group.knobs[key], key: key }
+                                        "
+                                    >
+                                    </ng-template>
+                                </ng-container>
+                            </mat-expansion-panel>
+                        </mat-accordion>
+                    </ng-container>
+
+                    <ng-container *ngIf="knobGroups.length === 1">
+                        <div class="blui-subtitle-1 primary" style="margin-bottom: 16px;">
+                            {{ knobGroups[0].title }}
+                        </div>
+                        <ng-container *ngFor="let key of getKeys(knobGroups[0].knobs)">
+                            <ng-template
+                                *ngTemplateOutlet="
+                                    interactiveKnob;
+                                    context: { knob: knobGroups[0].knobs[key], key: key }
+                                "
+                            >
+                            </ng-template>
+                        </ng-container>
+                    </ng-container>
                 </div>
             </div>
         </div>
+
+        <ng-template #interactiveKnob let-knob="knob" let-key="key">
+            <app-select-knob
+                *ngIf="knob.type === 'select'"
+                [label]="knob.label || key"
+                [options]="knob.options"
+                [(value)]="knob.value"
+                [hint]="knob.hint"
+                (valueChange)="emitKnobChange()"
+            ></app-select-knob>
+            <app-color-knob
+                *ngIf="knob.type === 'color'"
+                [label]="knob.label || key"
+                [(value)]="knob.value"
+                [hint]="knob.hint"
+                (valueChange)="emitKnobChange()"
+            ></app-color-knob>
+            <app-text-knob
+                *ngIf="knob.type === 'string'"
+                [label]="knob.label || key"
+                [(value)]="knob.value"
+                [hint]="knob.hint"
+                (valueChange)="emitKnobChange()"
+            ></app-text-knob>
+            <app-boolean-knob
+                *ngIf="knob.type === 'boolean'"
+                [label]="knob.label || key"
+                [(value)]="knob.value"
+                [hint]="knob.hint"
+                (valueChange)="emitKnobChange()"
+            ></app-boolean-knob>
+            <app-number-knob
+                *ngIf="knob.type === 'number'"
+                [label]="knob.label || key"
+                [(value)]="knob.value"
+                [max]="knob.range.max"
+                [min]="knob.range.min"
+                [hint]="knob.hint"
+                (valueChange)="emitKnobChange()"
+            ></app-number-knob>
+        </ng-template>
     `,
     styleUrls: ['./scaffold.component.scss'],
     encapsulation: ViewEncapsulation.None,

--- a/src/docs/pages/component-docs/shared/scaffold/scaffold.component.ts
+++ b/src/docs/pages/component-docs/shared/scaffold/scaffold.component.ts
@@ -58,37 +58,46 @@ export type Knob = {
                     </div>
                 </div>
                 <div class="props-container">
-                    <ng-container *ngFor="let key of getKeys()">
-                        <app-select-knob
-                            *ngIf="knobs[key].type === 'select'"
-                            [label]="knobs[key].label || key"
-                            [options]="knobs[key].options"
-                            [(value)]="knobs[key].value"
-                            [hint]="knobs[key].hint"
-                            (valueChange)="emitKnobChange(knobs)"
-                        ></app-select-knob>
-                        <app-color-knob
-                            *ngIf="knobs[key].type === 'color'"
-                            [label]="knobs[key].label || key"
-                            [(value)]="knobs[key].value"
-                            [hint]="knobs[key].hint"
-                            (valueChange)="emitKnobChange(knobs)"
-                        ></app-color-knob>
-                        <app-text-knob
-                            *ngIf="knobs[key].type === 'string'"
-                            [label]="knobs[key].label || key"
-                            [(value)]="knobs[key].value"
-                            [hint]="knobs[key].hint"
-                            (valueChange)="emitKnobChange(knobs)"
-                        ></app-text-knob>
-                        <app-boolean-knob
-                            *ngIf="knobs[key].type === 'boolean'"
-                            [label]="knobs[key].label || key"
-                            [(value)]="knobs[key].value"
-                            [hint]="knobs[key].hint"
-                            (valueChange)="emitKnobChange(knobs)"
-                        ></app-boolean-knob>
-                    </ng-container>
+                    <mat-accordion *ngFor="let group of knobGroups">
+                        <mat-expansion-panel [expanded]="group.defaultExpanded" class="mat-elevation-z0">
+                            <mat-expansion-panel-header>
+                                <mat-panel-title>
+                                    {{ group.title }}
+                                </mat-panel-title>
+                            </mat-expansion-panel-header>
+                            <ng-container *ngFor="let key of getKeys()">
+                                <app-select-knob
+                                        *ngIf="knobs[key].type === 'select'"
+                                        [label]="knobs[key].label || key"
+                                        [options]="knobs[key].options"
+                                        [(value)]="knobs[key].value"
+                                        [hint]="knobs[key].hint"
+                                        (valueChange)="emitKnobChange(knobs)"
+                                ></app-select-knob>
+                                <app-color-knob
+                                        *ngIf="knobs[key].type === 'color'"
+                                        [label]="knobs[key].label || key"
+                                        [(value)]="knobs[key].value"
+                                        [hint]="knobs[key].hint"
+                                        (valueChange)="emitKnobChange(knobs)"
+                                ></app-color-knob>
+                                <app-text-knob
+                                        *ngIf="knobs[key].type === 'string'"
+                                        [label]="knobs[key].label || key"
+                                        [(value)]="knobs[key].value"
+                                        [hint]="knobs[key].hint"
+                                        (valueChange)="emitKnobChange(knobs)"
+                                ></app-text-knob>
+                                <app-boolean-knob
+                                        *ngIf="knobs[key].type === 'boolean'"
+                                        [label]="knobs[key].label || key"
+                                        [(value)]="knobs[key].value"
+                                        [hint]="knobs[key].hint"
+                                        (valueChange)="emitKnobChange(knobs)"
+                                ></app-boolean-knob>
+                            </ng-container>
+                        </mat-expansion-panel>
+                    </mat-accordion>
                 </div>
             </div>
         </div>
@@ -101,6 +110,8 @@ export class ScaffoldComponent implements OnInit, OnDestroy {
     @Input() mdFileName: string;
     @Input() md: string;
     @Input() knobs: { [key: string]: Knob };
+    @Input() knobGroups: Array<{ title: string, knobs: [key: string], defaultExpanded: boolean; }>;
+
 
     currentTabIndex = 0;
 

--- a/src/docs/pages/component-docs/shared/scaffold/scaffold.component.ts
+++ b/src/docs/pages/component-docs/shared/scaffold/scaffold.component.ts
@@ -99,44 +99,46 @@ export type Knob = {
         </div>
 
         <ng-template #interactiveKnob let-knob="knob" let-key="key">
-            <app-select-knob
-                *ngIf="knob.type === 'select'"
-                [label]="knob.label || key"
-                [options]="knob.options"
-                [(value)]="knob.value"
-                [hint]="knob.hint"
-                (valueChange)="emitKnobChange()"
-            ></app-select-knob>
-            <app-color-knob
-                *ngIf="knob.type === 'color'"
-                [label]="knob.label || key"
-                [(value)]="knob.value"
-                [hint]="knob.hint"
-                (valueChange)="emitKnobChange()"
-            ></app-color-knob>
-            <app-text-knob
-                *ngIf="knob.type === 'string'"
-                [label]="knob.label || key"
-                [(value)]="knob.value"
-                [hint]="knob.hint"
-                (valueChange)="emitKnobChange()"
-            ></app-text-knob>
-            <app-boolean-knob
-                *ngIf="knob.type === 'boolean'"
-                [label]="knob.label || key"
-                [(value)]="knob.value"
-                [hint]="knob.hint"
-                (valueChange)="emitKnobChange()"
-            ></app-boolean-knob>
-            <app-number-knob
-                *ngIf="knob.type === 'number'"
-                [label]="knob.label || key"
-                [(value)]="knob.value"
-                [max]="knob.range.max"
-                [min]="knob.range.min"
-                [hint]="knob.hint"
-                (valueChange)="emitKnobChange()"
-            ></app-number-knob>
+            <div [class.non-prop]="knob.label?.indexOf(' ') > 0">
+                <app-select-knob
+                    *ngIf="knob.type === 'select'"
+                    [label]="knob.label || key"
+                    [options]="knob.options"
+                    [(value)]="knob.value"
+                    [hint]="knob.hint"
+                    (valueChange)="emitKnobChange()"
+                ></app-select-knob>
+                <app-color-knob
+                    *ngIf="knob.type === 'color'"
+                    [label]="knob.label || key"
+                    [(value)]="knob.value"
+                    [hint]="knob.hint"
+                    (valueChange)="emitKnobChange()"
+                ></app-color-knob>
+                <app-text-knob
+                    *ngIf="knob.type === 'string'"
+                    [label]="knob.label || key"
+                    [(value)]="knob.value"
+                    [hint]="knob.hint"
+                    (valueChange)="emitKnobChange()"
+                ></app-text-knob>
+                <app-boolean-knob
+                    *ngIf="knob.type === 'boolean'"
+                    [label]="knob.label || key"
+                    [(value)]="knob.value"
+                    [hint]="knob.hint"
+                    (valueChange)="emitKnobChange()"
+                ></app-boolean-knob>
+                <app-number-knob
+                    *ngIf="knob.type === 'number'"
+                    [label]="knob.label || key"
+                    [(value)]="knob.value"
+                    [max]="knob.range.max"
+                    [min]="knob.range.min"
+                    [hint]="knob.hint"
+                    (valueChange)="emitKnobChange()"
+                ></app-number-knob>
+            </div>
         </ng-template>
     `,
     styleUrls: ['./scaffold.component.scss'],

--- a/src/docs/pages/component-docs/shared/scaffold/scaffold.component.ts
+++ b/src/docs/pages/component-docs/shared/scaffold/scaffold.component.ts
@@ -61,7 +61,7 @@ export type Knob = {
                     <mat-accordion *ngFor="let group of knobGroups">
                         <mat-expansion-panel [expanded]="group.defaultExpanded" class="mat-elevation-z0">
                             <mat-expansion-panel-header>
-                                <mat-panel-title>
+                                <mat-panel-title class="blui-subtitle-1">
                                     {{ group.title }}
                                 </mat-panel-title>
                             </mat-expansion-panel-header>

--- a/src/docs/pages/component-docs/shared/scaffold/scaffold.component.ts
+++ b/src/docs/pages/component-docs/shared/scaffold/scaffold.component.ts
@@ -12,6 +12,7 @@ export type Knob = {
     label?: string;
     value: any;
     componentDefault?: string | boolean | number;
+    range?: { min: number; max: number };
     type: 'string' | 'color' | 'select' | 'number' | 'boolean';
     hint: string;
     options?: string[];
@@ -95,6 +96,15 @@ export type Knob = {
                                     [hint]="group.knobs[key].hint"
                                     (valueChange)="emitKnobChange()"
                                 ></app-boolean-knob>
+                                <app-number-knob
+                                    *ngIf="group.knobs[key].type === 'number'"
+                                    [label]="group.knobs[key].label || key"
+                                    [(value)]="group.knobs[key].value"
+                                    [max]="group.knobs[key].range.max"
+                                    [min]="group.knobs[key].range.min"
+                                    [hint]="group.knobs[key].hint"
+                                    (valueChange)="emitKnobChange()"
+                                ></app-number-knob>
                             </ng-container>
                         </mat-expansion-panel>
                     </mat-accordion>

--- a/src/docs/pages/component-docs/shared/shared-comp-docs.module.ts
+++ b/src/docs/pages/component-docs/shared/shared-comp-docs.module.ts
@@ -6,7 +6,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { CommonModule } from '@angular/common';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { KnobTextComponent } from './knobs/knob-text.component';
 import { AppCommonComponentsModule } from '../../../components/components.module';
 import { MatButtonModule } from '@angular/material/button';
@@ -71,6 +71,7 @@ import { OverlayModule } from '@angular/cdk/overlay';
             },
         }),
         MatDividerModule,
+        ReactiveFormsModule,
     ],
     exports: [
         ExampleCodeComponent,

--- a/src/docs/pages/component-docs/shared/shared-comp-docs.module.ts
+++ b/src/docs/pages/component-docs/shared/shared-comp-docs.module.ts
@@ -22,6 +22,7 @@ import { ColorPickerModule } from 'ngx-color-picker';
 import { KnobSelectComponent } from './knobs/knob-select.component';
 import { MatSelectModule } from '@angular/material/select';
 import { MatDividerModule } from '@angular/material/divider';
+import {MatExpansionModule} from "@angular/material/expansion";
 
 @NgModule({
     declarations: [
@@ -41,6 +42,7 @@ import { MatDividerModule } from '@angular/material/divider';
         ColorPickerModule,
         MatIconModule,
         MatCheckboxModule,
+        MatExpansionModule,
         HttpClientModule,
         MatFormFieldModule,
         MatInputModule,

--- a/src/docs/pages/component-docs/shared/shared-comp-docs.module.ts
+++ b/src/docs/pages/component-docs/shared/shared-comp-docs.module.ts
@@ -22,7 +22,7 @@ import { ColorPickerModule } from 'ngx-color-picker';
 import { KnobSelectComponent } from './knobs/knob-select.component';
 import { MatSelectModule } from '@angular/material/select';
 import { MatDividerModule } from '@angular/material/divider';
-import {MatExpansionModule} from "@angular/material/expansion";
+import { MatExpansionModule } from '@angular/material/expansion';
 
 @NgModule({
     declarations: [

--- a/src/docs/pages/component-docs/shared/shared-comp-docs.module.ts
+++ b/src/docs/pages/component-docs/shared/shared-comp-docs.module.ts
@@ -23,6 +23,9 @@ import { KnobSelectComponent } from './knobs/knob-select.component';
 import { MatSelectModule } from '@angular/material/select';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatExpansionModule } from '@angular/material/expansion';
+import { KnobNumberComponent } from './knobs/knob-number.component';
+import { MatSliderModule } from '@angular/material/slider';
+import { OverlayModule } from '@angular/cdk/overlay';
 
 @NgModule({
     declarations: [
@@ -35,6 +38,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
         KnobBooleanComponent,
         KnobColorComponent,
         KnobSelectComponent,
+        KnobNumberComponent,
     ],
     imports: [
         AppCommonComponentsModule,
@@ -45,6 +49,8 @@ import { MatExpansionModule } from '@angular/material/expansion';
         MatExpansionModule,
         HttpClientModule,
         MatFormFieldModule,
+        MatSliderModule,
+        OverlayModule,
         MatInputModule,
         MatTabsModule,
         MatSelectModule,
@@ -80,6 +86,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
         KnobBooleanComponent,
         KnobColorComponent,
         KnobSelectComponent,
+        KnobNumberComponent,
     ],
 })
 export class SharedCompDocsModule {}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -19,9 +19,6 @@ body {
     }
 }
 
-.number-knob-backdrop {
-}
-
 .color-picker .arrow.arrow-bottom {
     display: none;
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -19,10 +19,12 @@ body {
     }
 }
 
+.number-knob-backdrop {
+}
+
 .color-picker .arrow.arrow-bottom {
     display: none;
 }
-
 /** Examples Pages */
 .app-example {
     .example-heading {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -11,6 +11,7 @@ body {
 .blui-blue {
     @include doc-light.light-theme();
 }
+
 // This is required for the demos, otherwise will need to specify the height on the drawer in each demo.
 .app-example,
 .playground-container {

--- a/src/themes/doc-light.scss
+++ b/src/themes/doc-light.scss
@@ -12,7 +12,7 @@
         color: $primary !important;
     }
 
-    app-copy-code-button .mat-button-base.mat-stroked-button.mat-primary {
+    .playground-container app-copy-code-button .mat-button-base.mat-stroked-button.mat-primary {
         color: map-get(blui.$blui-blue, 200);
         border-color: map-get(blui.$blui-blue, 200);
     }

--- a/src/themes/doc-light.scss
+++ b/src/themes/doc-light.scss
@@ -25,6 +25,7 @@
         border-color: map-get(blui.$blui-blue, 200);
         background-color: #2d2d2d;
     }
+
     .props-container {
         border-left: solid 1px $divider;
     }

--- a/src/themes/doc-light.scss
+++ b/src/themes/doc-light.scss
@@ -12,6 +12,10 @@
         color: $primary !important;
     }
 
+    .divider-border {
+        border: solid 1px $divider;
+    }
+
     .playground-container app-copy-code-button .mat-button-base.mat-stroked-button.mat-primary {
         color: map-get(blui.$blui-blue, 200);
         border-color: map-get(blui.$blui-blue, 200);

--- a/src/themes/doc-light.scss
+++ b/src/themes/doc-light.scss
@@ -4,6 +4,10 @@
     $primary: map-get(blui.$blui-blue, 500);
     $divider: rgba(map-get(blui.$blui-black, 500), 0.12);
 
+    .primary {
+        color: $primary;
+    }
+
     a {
         color: $primary !important;
     }

--- a/src/themes/doc-light.scss
+++ b/src/themes/doc-light.scss
@@ -23,6 +23,7 @@
     .playground-container app-copy-code-button .mat-button-base.mat-stroked-button.mat-primary {
         color: map-get(blui.$blui-blue, 200);
         border-color: map-get(blui.$blui-blue, 200);
+        background-color: #2d2d2d;
     }
 
     .emptySelectOption {

--- a/src/themes/doc-light.scss
+++ b/src/themes/doc-light.scss
@@ -12,6 +12,11 @@
         color: $primary !important;
     }
 
+    app-copy-code-button .mat-button-base.mat-stroked-button.mat-primary {
+        color: map-get(blui.$blui-blue, 200);
+        border-color: map-get(blui.$blui-blue, 200);
+    }
+
     .emptySelectOption {
         border-bottom: solid 1px $divider;
     }

--- a/src/themes/doc-light.scss
+++ b/src/themes/doc-light.scss
@@ -16,6 +16,10 @@
         border: solid 1px $divider;
     }
 
+    .slider-knob-overlay {
+        background-color: map-get(blui.$blui-white, 50);
+    }
+
     .playground-container app-copy-code-button .mat-button-base.mat-stroked-button.mat-primary {
         color: map-get(blui.$blui-blue, 200);
         border-color: map-get(blui.$blui-blue, 200);

--- a/src/themes/doc-light.scss
+++ b/src/themes/doc-light.scss
@@ -25,6 +25,9 @@
         border-color: map-get(blui.$blui-blue, 200);
         background-color: #2d2d2d;
     }
+    .props-container {
+        border-left: solid 1px $divider;
+    }
 
     .emptySelectOption {
         border-bottom: solid 1px $divider;

--- a/src/themes/doc-light.scss
+++ b/src/themes/doc-light.scss
@@ -5,7 +5,7 @@
     $divider: rgba(map-get(blui.$blui-black, 500), 0.12);
 
     .primary {
-        color: $primary;
+        color: $primary !important;
     }
 
     a {


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Update the color picker to match the figma designs
- Group Props by Type (required, optional)
- Add a copy code button on generated snippet, on playground pages
- Generated code is 30% height, live-example is 70% height on playground.
- Playground input values are now Monospaced
- Color picker has an error state on invalid value
- Number slider no longer shows arrows on hover
- If only a single section of properties on playground, do not show an accordion.

